### PR TITLE
Re-add CentOS to build/release process

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -55,4 +55,4 @@ RUN mkdir /.cargo
 RUN chmod +rx /.cargo
 COPY build/cargo-config /.cargo/config
 
-CMD ["/opt/build.sh"]
+CMD ["/opt/build_osx.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all build build-rust build-go test docker-image docker-build docker-image-centos7
 
-DOCKER_TAG := 0.7.0
+DOCKER_TAG := 0.7.1
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)
 
@@ -58,14 +58,13 @@ docker-image-centos7:
 docker-image-cross:
 	docker build . -t cosmwasm/go-ext-builder:$(DOCKER_TAG)-cross -f ./Dockerfile.cross
 
-# docker-images: docker-image-centos7 docker-image-cross
-docker-images: docker-image-cross
+docker-images: docker-image-centos7 docker-image-cross
 
 docker-publish: docker-images
 	docker push cosmwasm/go-ext-builder:$(DOCKER_TAG)-cross
-# 	docker push cosmwasm/go-ext-builder:$(DOCKER_TAG)-centos7
+	docker push cosmwasm/go-ext-builder:$(DOCKER_TAG)-centos7
 
 # and use them to compile release builds
 release:
 	docker run --rm -u $(USER_ID):$(USER_GROUP) -v $(shell pwd):/code cosmwasm/go-ext-builder:$(DOCKER_TAG)-cross
-# 	docker run --rm -u $(USER_ID):$(USER_GROUP) -v $(shell pwd):/code cosmwasm/go-ext-builder:$(DOCKER_TAG)-centos7
+	docker run --rm -u $(USER_ID):$(USER_GROUP) -v $(shell pwd):/code cosmwasm/go-ext-builder:$(DOCKER_TAG)-centos7


### PR DESCRIPTION
I removed it for `v0.7.1` as I had some issues.
Seems these were local build issues not with the CentOS docker image, and now I re-enable it