### PR TITLE
Remove Buffer.is_empty

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -66,6 +66,27 @@ mod test {
     use super::*;
 
     #[test]
+    fn read_works() {
+        let buffer1 = Buffer::from_vec(vec![0xAA]);
+        assert_eq!(buffer1.read(), Some(&[0xAAu8] as &[u8]));
+
+        let buffer2 = Buffer::from_vec(vec![0xAA, 0xBB, 0xCC]);
+        assert_eq!(buffer2.read(), Some(&[0xAAu8, 0xBBu8, 0xCCu8] as &[u8]));
+
+        let buffer3 = Buffer::from_vec(Vec::new());
+        assert_eq!(buffer3.read(), None);
+
+        let buffer4 = Buffer::with_capacity(7);
+        assert_eq!(buffer4.read(), None);
+
+        // Cleanup
+        unsafe { buffer1.consume() };
+        unsafe { buffer2.consume() };
+        unsafe { buffer3.consume() };
+        unsafe { buffer4.consume() };
+    }
+
+    #[test]
     fn with_capacity_works() {
         let buffer = Buffer::with_capacity(7);
         assert_eq!(buffer.ptr.is_null(), false);

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -22,7 +22,7 @@ impl Buffer {
     // data is only guaranteed to live as long as the Buffer
     // (or the scope of the extern "C" call it came from)
     pub fn read(&self) -> Option<&[u8]> {
-        if self.is_empty() {
+        if self.len == 0 {
             None
         } else {
             unsafe { Some(slice::from_raw_parts(self.ptr, self.len)) }
@@ -54,10 +54,6 @@ impl Buffer {
             len: v.len(),
             cap: v.capacity(),
         }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.ptr.is_null() || self.len == 0 || self.cap == 0
     }
 }
 


### PR DESCRIPTION
This function does many things at once and it is unclear what the purpose of those check is. A Buffer with `len != 0` and `ptr = 0` or `capacity = 0` sounds broken and should be fixed at its source.