### PR TITLE
Avoid installing unused Rust version; Run clippy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,13 @@ jobs:
     docker:
       - image: circleci/rust:1.41-stretch
     steps:
-      - run: rustup toolchain install nightly
+      - checkout
+      - run:
+          name: Setup Rust toolchain from ./rust-toolchain
+          command: echo "RUSTUP_TOOLCHAIN=$RUSTUP_TOOLCHAIN" && rustup show
       - run:
           name: Show version information
           command: rustc --version; cargo --version; rustup --version
-      - checkout
       - run:
           name: Run tests
           command: cargo test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,12 @@ jobs:
           name: Show version information
           command: rustc --version; cargo --version; rustup --version
       - run:
+          name: Add clippy component
+          command: rustup component add clippy
+      - run:
+          name: Run linter
+          command: cargo clippy -- -D warnings
+      - run:
           name: Run tests
           command: cargo test
       - run:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.go]
+indent_style = tab
+indent_size = 4

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 8


### PR DESCRIPTION
`rustup toolchain install nightly` installed a toolchain that was never used