### PR TITLE
Fix error parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,8 +227,8 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.8.0-rc1"
-source = "git+https://github.com/cosmwasm/cosmwasm?rev=v0.8.0-rc1#75a6a413608a77e29b5c7576949be8405a96450b"
+version = "0.8.0"
+source = "git+https://github.com/cosmwasm/cosmwasm?rev=v0.8.0#2318a71de9d06a6d2064d88c27d31220a831ab60"
 dependencies = [
  "base64",
  "schemars",
@@ -239,8 +239,8 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.8.0-rc1"
-source = "git+https://github.com/cosmwasm/cosmwasm?rev=v0.8.0-rc1#75a6a413608a77e29b5c7576949be8405a96450b"
+version = "0.8.0"
+source = "git+https://github.com/cosmwasm/cosmwasm?rev=v0.8.0#2318a71de9d06a6d2064d88c27d31220a831ab60"
 dependencies = [
  "cosmwasm-std",
  "hex",
@@ -492,7 +492,7 @@ checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "go-cosmwasm"
-version = "0.8.0-alpha3"
+version = "0.8.0"
 dependencies = [
  "cbindgen",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-cosmwasm"
-version = "0.8.0-alpha3"
+version = "0.8.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Go bindings for cosmwasm contracts"
@@ -24,8 +24,8 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 cranelift = ["cosmwasm-vm/default-cranelift"]
 
 [dependencies]
-cosmwasm-std = { git = "https://github.com/cosmwasm/cosmwasm", rev = "v0.8.0-rc1", features = ["iterator"]}
-cosmwasm-vm = { git = "https://github.com/cosmwasm/cosmwasm", rev = "v0.8.0-rc1", features = ["iterator"] }
+cosmwasm-std = { git = "https://github.com/cosmwasm/cosmwasm", rev = "v0.8.0", features = ["iterator"]}
+cosmwasm-vm = { git = "https://github.com/cosmwasm/cosmwasm", rev = "v0.8.0", features = ["iterator"] }
 errno = "0.2"
 snafu = "0.6.3"
 serde_json = "1.0"

--- a/types/stderror.go
+++ b/types/stderror.go
@@ -16,7 +16,7 @@ type StdError struct {
 	ParseErr      *ParseErr      `json:"parse_err,omitempty"`
 	SerializeErr  *SerializeErr  `json:"serialize_err,omitempty"`
 	Unauthorized  *Unauthorized  `json:"unauthorized,omitempty"`
-	UnderflowErr  *UnderflowErr  `json:"underflow_err,omitempty"`
+	Underflow     *Underflow     `json:"underflow,omitempty"`
 }
 
 var (
@@ -28,7 +28,7 @@ var (
 	_ error = ParseErr{}
 	_ error = SerializeErr{}
 	_ error = Unauthorized{}
-	_ error = UnderflowErr{}
+	_ error = Underflow{}
 )
 
 func (a StdError) Error() string {
@@ -49,8 +49,8 @@ func (a StdError) Error() string {
 		return a.SerializeErr.Error()
 	case a.Unauthorized != nil:
 		return a.Unauthorized.Error()
-	case a.UnderflowErr != nil:
-		return a.UnderflowErr.Error()
+	case a.Underflow != nil:
+		return a.Underflow.Error()
 	default:
 		panic("unknown error variant")
 	}
@@ -118,12 +118,12 @@ func (e Unauthorized) Error() string {
 	return "unauthorized"
 }
 
-type UnderflowErr struct {
+type Underflow struct {
 	Minuend    string `json:"minuend,omitempty"`
 	Subtrahend string `json:"subtrahend,omitempty"`
 }
 
-func (e UnderflowErr) Error() string {
+func (e Underflow) Error() string {
 	return fmt.Sprintf("underflow: %s - %s", e.Minuend, e.Subtrahend)
 }
 
@@ -170,10 +170,10 @@ func ToStdError(err error) *StdError {
 		return &StdError{Unauthorized: &t}
 	case *Unauthorized:
 		return &StdError{Unauthorized: t}
-	case UnderflowErr:
-		return &StdError{UnderflowErr: &t}
-	case *UnderflowErr:
-		return &StdError{UnderflowErr: t}
+	case Underflow:
+		return &StdError{Underflow: &t}
+	case *Underflow:
+		return &StdError{Underflow: t}
 	default:
 		g := GenericErr{Msg: err.Error()}
 		return &StdError{GenericErr: &g}

--- a/types/stderror.go
+++ b/types/stderror.go
@@ -25,6 +25,7 @@ var (
 	_ error = InvalidBase64{}
 	_ error = InvalidUtf8{}
 	_ error = NotFound{}
+	_ error = NullPointer{}
 	_ error = ParseErr{}
 	_ error = SerializeErr{}
 	_ error = Unauthorized{}
@@ -158,6 +159,10 @@ func ToStdError(err error) *StdError {
 		return &StdError{NotFound: &t}
 	case *NotFound:
 		return &StdError{NotFound: t}
+	case NullPointer:
+		return &StdError{NullPointer: &t}
+	case *NullPointer:
+		return &StdError{NullPointer: t}
 	case ParseErr:
 		return &StdError{ParseErr: &t}
 	case *ParseErr:


### PR DESCRIPTION
This updates the go error types to properly parse the updated json from the rust side. In particular, the name `unauthorized_err` changed to `unauthorized`. We added `SystemError::InvalidResponse`, and added the original request field to the `SystemError::InvalidRequest` type