### PR TITLE
Gas meter in db data

### DIFF
--- a/api/bindings.h
+++ b/api/bindings.h
@@ -53,13 +53,6 @@ typedef struct cache_t {
 
 } cache_t;
 
-/**
- * An opaque type. `*gas_meter_t` represents a pointer to Go memory holding the gas meter.
- */
-typedef struct gas_meter_t {
-  uint8_t _private[0];
-} gas_meter_t;
-
 typedef struct db_t {
   uint8_t _private[0];
 } db_t;
@@ -69,24 +62,22 @@ typedef struct iterator_t {
 } iterator_t;
 
 typedef struct Iterator_vtable {
-  int32_t (*next_db)(iterator_t*, gas_meter_t*, uint64_t*, Buffer*, Buffer*);
+  int32_t (*next_db)(iterator_t*, uint64_t*, Buffer*, Buffer*);
 } Iterator_vtable;
 
 typedef struct GoIter {
-  gas_meter_t *gas_meter;
   iterator_t *state;
   Iterator_vtable vtable;
 } GoIter;
 
 typedef struct DB_vtable {
-  int32_t (*read_db)(db_t*, gas_meter_t*, uint64_t*, Buffer, Buffer*);
-  int32_t (*write_db)(db_t*, gas_meter_t*, uint64_t*, Buffer, Buffer);
-  int32_t (*remove_db)(db_t*, gas_meter_t*, uint64_t*, Buffer);
-  int32_t (*scan_db)(db_t*, gas_meter_t*, uint64_t*, Buffer, Buffer, int32_t, GoIter*);
+  int32_t (*read_db)(db_t*, uint64_t*, Buffer, Buffer*);
+  int32_t (*write_db)(db_t*, uint64_t*, Buffer, Buffer);
+  int32_t (*remove_db)(db_t*, uint64_t*, Buffer);
+  int32_t (*scan_db)(db_t*, uint64_t*, Buffer, Buffer, int32_t, GoIter*);
 } DB_vtable;
 
 typedef struct DB {
-  gas_meter_t *gas_meter;
   db_t *state;
   DB_vtable vtable;
 } DB;

--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -126,8 +126,9 @@ type dbState struct {
 	gm GasMeter
 }
 
-func buildDBState(kv KVStore, gm GasMeter) dbState {
-	return dbState{kv, gm}
+func buildDBState(kv KVStore, gm GasMeter) *dbState {
+	// Hopefully this `&` moves the object to the heap, where it _won't_ be GC'ed
+	return &dbState{kv, gm}
 }
 
 // contract: original pointer/struct referenced must live longer than C.DB struct
@@ -148,8 +149,9 @@ type iteratorState struct {
 	gm GasMeter
 }
 
-func buildIteratorState(iter dbm.Iterator, gm GasMeter) iteratorState {
-	return iteratorState{iter, gm}
+func buildIteratorState(iter dbm.Iterator, gm GasMeter) *iteratorState {
+	// Hopefully this `&` moves the object to the heap, where it _won't_ be GC'ed
+	return &iteratorState{iter, gm}
 }
 
 // contract: original pointer/struct referenced must live longer than C.DB struct
@@ -269,7 +271,7 @@ func cScan(ptr *C.db_t, usedGas *C.uint64_t, start C.Buffer, end C.Buffer, order
 
 	// Let's hope this works!
 	iteratorState := buildIteratorState(iter, gm)
-	*out = buildIterator(&iteratorState)
+	*out = buildIterator(iteratorState)
 	return C.GoResult_Ok
 }
 

--- a/api/callbacks_cgo.go
+++ b/api/callbacks_cgo.go
@@ -5,12 +5,12 @@ package api
 #include <stdio.h>
 
 // imports (db)
-GoResult cSet(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer key, Buffer val);
-GoResult cGet(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer key, Buffer *val);
-GoResult cDelete(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer key);
-GoResult cScan(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer start, Buffer end, int32_t order, GoIter *out);
+GoResult cSet(db_t *ptr, uint64_t *used_gas, Buffer key, Buffer val);
+GoResult cGet(db_t *ptr, uint64_t *used_gas, Buffer key, Buffer *val);
+GoResult cDelete(db_t *ptr, uint64_t *used_gas, Buffer key);
+GoResult cScan(db_t *ptr, uint64_t *used_gas, Buffer start, Buffer end, int32_t order, GoIter *out);
 // imports (iterator)
-GoResult cNext(iterator_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer *key, Buffer *val);
+GoResult cNext(iterator_t *ptr, uint64_t *used_gas, Buffer *key, Buffer *val);
 // imports (api)
 GoResult cHumanAddress(api_t *ptr, Buffer canon, Buffer *human);
 GoResult cCanonicalAddress(api_t *ptr, Buffer human, Buffer *canon);
@@ -18,22 +18,22 @@ GoResult cCanonicalAddress(api_t *ptr, Buffer human, Buffer *canon);
 GoResult cQueryExternal(querier_t *ptr, Buffer request, Buffer *result);
 
 // Gateway functions (db)
-GoResult cGet_cgo(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer key, Buffer *val) {
-	return cGet(ptr, gas_meter, used_gas, key, val);
+GoResult cGet_cgo(db_t *ptr, uint64_t *used_gas, Buffer key, Buffer *val) {
+	return cGet(ptr, used_gas, key, val);
 }
-GoResult cSet_cgo(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer key, Buffer val) {
-	return cSet(ptr, gas_meter, used_gas, key, val);
+GoResult cSet_cgo(db_t *ptr, uint64_t *used_gas, Buffer key, Buffer val) {
+	return cSet(ptr, used_gas, key, val);
 }
-GoResult cDelete_cgo(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer key) {
-	return cDelete(ptr, gas_meter, used_gas, key);
+GoResult cDelete_cgo(db_t *ptr, uint64_t *used_gas, Buffer key) {
+	return cDelete(ptr, used_gas, key);
 }
-GoResult cScan_cgo(db_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer start, Buffer end, int32_t order, GoIter *out) {
-	return cScan(ptr, gas_meter, used_gas, start, end, order, out);
+GoResult cScan_cgo(db_t *ptr, uint64_t *used_gas, Buffer start, Buffer end, int32_t order, GoIter *out) {
+	return cScan(ptr, used_gas, start, end, order, out);
 }
 
 // Gateway functions (iterator)
-GoResult cNext_cgo(iterator_t *ptr, gas_meter_t *gas_meter, uint64_t *used_gas, Buffer *key, Buffer *val) {
-	return cNext(ptr, gas_meter, used_gas, key, val);
+GoResult cNext_cgo(iterator_t *ptr, uint64_t *used_gas, Buffer *key, Buffer *val) {
+	return cNext(ptr, used_gas, key, val);
 }
 
 // Gateway functions (api)

--- a/api/lib.go
+++ b/api/lib.go
@@ -84,7 +84,8 @@ func Instantiate(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+	dbState := buildDBState(store, gasMeter)
+	db := buildDB(&dbState)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
@@ -114,7 +115,8 @@ func Handle(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+	dbState := buildDBState(store, gasMeter)
+	db := buildDB(&dbState)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
@@ -141,7 +143,8 @@ func Query(
 	defer freeAfterSend(id)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+	dbState := buildDBState(store, gasMeter)
+	db := buildDB(&dbState)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64

--- a/api/lib.go
+++ b/api/lib.go
@@ -85,7 +85,7 @@ func Instantiate(
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
 	dbState := buildDBState(store, gasMeter)
-	db := buildDB(&dbState)
+	db := buildDB(dbState)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
@@ -116,7 +116,7 @@ func Handle(
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
 	dbState := buildDBState(store, gasMeter)
-	db := buildDB(&dbState)
+	db := buildDB(dbState)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
@@ -144,7 +144,7 @@ func Query(
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
 	dbState := buildDBState(store, gasMeter)
-	db := buildDB(&dbState)
+	db := buildDB(dbState)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64

--- a/src/gas_meter.rs
+++ b/src/gas_meter.rs
@@ -1,5 +1,0 @@
-/// An opaque type. `*gas_meter_t` represents a pointer to Go memory holding the gas meter.
-#[repr(C)]
-pub struct gas_meter_t {
-    _private: [u8; 0],
-}

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,5 +1,4 @@
 use crate::error::GoResult;
-use crate::gas_meter::gas_meter_t;
 use crate::memory::Buffer;
 use cosmwasm_vm::{FfiError, FfiResult, StorageIteratorItem};
 
@@ -14,14 +13,11 @@ pub struct iterator_t {
 #[repr(C)]
 #[derive(Default)]
 pub struct Iterator_vtable {
-    pub next_db: Option<
-        extern "C" fn(*mut iterator_t, *mut gas_meter_t, *mut u64, *mut Buffer, *mut Buffer) -> i32,
-    >,
+    pub next_db: Option<extern "C" fn(*mut iterator_t, *mut u64, *mut Buffer, *mut Buffer) -> i32>,
 }
 
 #[repr(C)]
 pub struct GoIter {
-    pub gas_meter: *mut gas_meter_t,
     pub state: *mut iterator_t,
     pub vtable: Iterator_vtable,
 }
@@ -29,7 +25,6 @@ pub struct GoIter {
 impl Default for GoIter {
     fn default() -> Self {
         GoIter {
-            gas_meter: std::ptr::null_mut(),
             state: std::ptr::null_mut(),
             vtable: Iterator_vtable::default(),
         }
@@ -50,7 +45,6 @@ impl Iterator for GoIter {
         let mut used_gas = 0_u64;
         let go_result: GoResult = (next_db)(
             self.state,
-            self.gas_meter,
             &mut used_gas as *mut u64,
             &mut key_buf as *mut Buffer,
             &mut value_buf as *mut Buffer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 mod api;
 mod db;
 mod error;
-mod gas_meter;
 mod iterator;
 mod memory;
 mod querier;


### PR DESCRIPTION
This PR removes all references to the Go-side gas meter from Rust.
~I'm not sure if this is safe, but i took care to not do anything that we're not already doing today, so for example, when returning the iterator state pointer in `cScan`, I make sure that the iterator state is at least assigned to a variable in the same function that writes a pointer to it to a Rust object. hopefully this mitigates GC issues, but if it doesn't, well, everything else is just as broken.~

~Is there really no way to get a strong reference to a Go object in a foreign context? A large portion of this project assumes this is true, for pointers that we hold to Go objects.~

After ensuring that the `dbState` and `iteratorState` are heap allocated rather than stack allocated (which ensures that the pointers to them that we send to Rust are not stack pointers) the dynamic pointer checker in cGo triggers when running:
```bash
GODEBUG=cgocheck=2 make build-rust-debug test
```

To reviewer: lets add that `GODEBUG=cgocheck=2` flag to all Go test in the entire stack. I ran all the tests i could and fortunately nothing was triggered, but it's better to be safe than sorry (and make sure this is always checked in CI)  