### PR TITLE
Alpine build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 exclude = [".circleci/*", ".gitignore"]
 
 [lib]
-crate-type = ["cdylib"]
+# crate-type = ["cdylib"]
+crate-type = ["staticlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [badges]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,24 @@
+# this comes from standard alpine nightly file
+#  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
+# with some changes to support our toolchain, etc
+FROM alpine:3.12
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    apk add --no-cache \
+    ca-certificates \
+    gcc;
+
+RUN wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-musl/rustup-init"
+RUN chmod +x rustup-init
+RUN ./rustup-init -y --no-modify-path --default-toolchain nightly-2020-06-08; rm rustup-init
+RUN chmod -R a+w $RUSTUP_HOME $CARGO_HOME
+
+# needed for
+# /usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find crti.o: No such file or directory
+ENV LIBRARY_PATH=/usr/local/rustup/toolchains/nightly-2020-06-08-x86_64-unknown-linux-musl/lib/rustlib/x86_64-unknown-linux-musl/lib:$LIBRARY_PATH
+
+RUN rustup --version; cargo --version; rustc --version;

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ docker-image-centos7:
 docker-image-cross:
 	docker build . -t cosmwasm/go-ext-builder:$(DOCKER_TAG)-cross -f ./Dockerfile.cross
 
+docker-image-alpine:
+	docker build . -t demo-alpine -f ./Dockerfile.alpine
+
 docker-images: docker-image-centos7 docker-image-cross
 
 docker-publish: docker-images

--- a/build/alpine_test.sh
+++ b/build/alpine_test.sh
@@ -16,7 +16,18 @@ docker run -v $(pwd)/..:/code -w /code \
   --mount type=volume,source="gocosmwasm_alpine_cache",target=/code/target \
   ${IMAGE} ls target target/release
 
-
+## for wasmer
+#docker run -v $(pwd):/code -w /code \
+#  --mount type=volume,source="wasmer_alpine_cache",target=/code/target \
+#  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+#  demo-alpine:latest cargo build
+#
+## for cosmwasm
+#docker run -v $(pwd):/code -w /code/packages/std \
+#  --env RUSTFLAGS="-C target-feature=-crt-static" \
+#  --mount type=volume,source="cosmwasm_alpine_cache",target=/code/target \
+#  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+#  demo-alpine:latest cargo build
 
 
 #docker run -v $(pwd):/code

--- a/build/alpine_test.sh
+++ b/build/alpine_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#IMAGE=rust:alpine3.11
+IMAGE=demo-alpine:latest
+
+#docker run -it -v $(pwd)/..:/code -w /code \
+#  --mount type=volume,source="gocosmwasm_alpine_cache",target=/code/target \
+#  ${IMAGE} /bin/sh
+
+docker run -v $(pwd)/..:/code -w /code \
+  --mount type=volume,source="gocosmwasm_alpine_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  ${IMAGE} cargo build --release --features backtraces
+
+docker run -v $(pwd)/..:/code -w /code \
+  --mount type=volume,source="gocosmwasm_alpine_cache",target=/code/target \
+  ${IMAGE} ls target target/release
+
+
+
+
+#docker run -v $(pwd):/code


### PR DESCRIPTION
Closes #103 

This is a bit trickier than I hoped. Happy if anyone wants to reproduce and try to follow.

```sh
# this takes Dockerfile.alpine and builds demo-alpine:latest
make docker-image-alpine

cd build
# this will run the compilation steps... edit this til it works
./alpine_test.sh
```

I went through a few passes, where I realized you need to set `crate_type=["staticlib"]` (this should be configured for one target later, but for now let's just hack until it works). Then it was complaining about not finding `crti.o` which is a rust internal lib, and I updated LIBRARY_PATH.

Now, it all compiles and I get to an `ld` error saying it cannot find `-lc`. I am not sure what I need to add here. Is this glibc it is requesting???

Note: the alpine linux docker just sets up rust and any other dependencies / libraries that are needed to compile. The alpine_test.sh is a fast way to test different compiler options. If/when this compiles this all needs to be refactored, but this was the quickest debug cycle I could find.