### PR TITLE
Let GoResult to Result<(), FfiError> conversion fail for GoResult::Other

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,9 @@
-use crate::iterator::GoIter;
-use cosmwasm_vm::{FfiResult, ReadonlyStorage, Storage, StorageIteratorItem};
+use cosmwasm_vm::{FfiError, FfiResult, ReadonlyStorage, Storage, StorageIteratorItem};
+use std::convert::TryInto;
 
 use crate::error::GoResult;
 use crate::gas_meter::gas_meter_t;
+use crate::iterator::GoIter;
 use crate::memory::Buffer;
 
 // this represents something passed in from the caller side of FFI
@@ -51,13 +52,12 @@ impl ReadonlyStorage for DB {
         )
         .into();
         let _key = unsafe { key_buf.consume() };
-        let mut go_result: FfiResult<()> = go_result.into();
-        if let Err(ref mut error) = go_result {
-            error.set_message(format!(
+        let go_result: FfiResult<()> = go_result.try_into().unwrap_or_else(|_| {
+            Err(FfiError::other(format!(
                 "Failed to read a key in the db: {}",
                 String::from_utf8_lossy(key)
-            ));
-        }
+            )))
+        });
         go_result?;
 
         if result_buf.ptr.is_null() {
@@ -100,15 +100,13 @@ impl ReadonlyStorage for DB {
         .into();
         let _start = unsafe { start_buf.consume() };
         let _end = unsafe { end_buf.consume() };
-
-        let mut go_result: FfiResult<()> = go_result.into();
-        if let Err(ref mut error) = go_result {
-            error.set_message(format!(
+        let go_result: FfiResult<()> = go_result.try_into().unwrap_or_else(|_| {
+            Err(FfiError::other(format!(
                 "Failed to read the next key between {:?} and {:?}",
                 start.map(String::from_utf8_lossy),
                 end.map(String::from_utf8_lossy),
-            ));
-        }
+            )))
+        });
         go_result?;
         Ok((Box::new(iter), used_gas))
     }
@@ -129,13 +127,12 @@ impl Storage for DB {
         .into();
         let _key = unsafe { key_buf.consume() };
         let _value = unsafe { value_buf.consume() };
-        let mut go_result: FfiResult<()> = go_result.into();
-        if let Err(ref mut error) = go_result {
-            error.set_message(format!(
+        let go_result: FfiResult<()> = go_result.try_into().unwrap_or_else(|_| {
+            Err(FfiError::other(format!(
                 "Failed to set a key in the db: {}",
                 String::from_utf8_lossy(key),
-            ));
-        }
+            )))
+        });
         go_result.and(Ok(used_gas))
     }
 
@@ -150,13 +147,12 @@ impl Storage for DB {
         )
         .into();
         let _key = unsafe { key_buf.consume() };
-        let mut go_result: FfiResult<()> = go_result.into();
-        if let Err(ref mut error) = go_result {
-            error.set_message(format!(
+        let go_result: FfiResult<()> = go_result.try_into().unwrap_or_else(|_| {
+            Err(FfiError::other(format!(
                 "Failed to delete a key in the db: {}",
                 String::from_utf8_lossy(key),
-            ));
-        }
+            )))
+        });
         go_result.and(Ok(used_gas))
     }
 }

--- a/src/error/go.rs
+++ b/src/error/go.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::fmt;
 
 use cosmwasm_vm::FfiError;
@@ -25,14 +26,16 @@ pub enum GoResult {
     Other = 4,
 }
 
-impl From<GoResult> for Result<(), FfiError> {
-    fn from(other: GoResult) -> Self {
+impl TryFrom<GoResult> for Result<(), FfiError> {
+    type Error = &'static str;
+
+    fn try_from(other: GoResult) -> Result<Self, Self::Error> {
         match other {
-            GoResult::Ok => Ok(()),
-            GoResult::Panic => Err(FfiError::foreign_panic()),
-            GoResult::BadArgument => Err(FfiError::bad_argument()),
-            GoResult::OutOfGas => Err(FfiError::out_of_gas()),
-            GoResult::Other => Err(FfiError::other("Unspecified error in Go code")),
+            GoResult::Ok => Ok(Ok(())),
+            GoResult::Panic => Ok(Err(FfiError::foreign_panic())),
+            GoResult::BadArgument => Ok(Err(FfiError::bad_argument())),
+            GoResult::OutOfGas => Ok(Err(FfiError::out_of_gas())),
+            GoResult::Other => Err("Unspecified error in Go code"), // no conversion possible due to missing error message
         }
     }
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,7 +1,9 @@
+use cosmwasm_vm::{FfiError, FfiResult, StorageIteratorItem};
+use std::convert::TryInto;
+
 use crate::error::GoResult;
 use crate::gas_meter::gas_meter_t;
 use crate::memory::Buffer;
-use cosmwasm_vm::{FfiError, FfiResult, StorageIteratorItem};
 
 // this represents something passed in from the caller side of FFI
 #[repr(C)]
@@ -56,10 +58,10 @@ impl Iterator for GoIter {
             &mut value_buf as *mut Buffer,
         )
         .into();
-        let mut go_result: FfiResult<()> = go_result.into();
-        if let Err(ref mut error) = go_result {
-            error.set_message("Failed to fetch next item from iterator");
-        }
+        let go_result: FfiResult<()> = go_result
+            .try_into()
+            .unwrap_or_else(|_| Err(FfiError::other("Failed to fetch next item from iterator")));
+
         if let Err(err) = go_result {
             return Some(Err(err));
         }


### PR DESCRIPTION
This change is for https://github.com/CosmWasm/cosmwasm/issues/336.

The implementation idea is: `GoResult` cannot be converted into `Result<(), FfiError>` because there is no corresponding `FfiError` for `GoResult::Other`. This is then filled with a context specific `FfiError::Other`.

So results become non-mutable and we can remove the mutable setter `FfiError::set_message`.