### PR TITLE
Store Iterators in Map, pass int reference over FFI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,10 @@ jobs:
       - attach_workspace:
           at: /tmp/builds
       - run: cp /tmp/builds/libgo_cosmwasm.so ./api
-      - run: make test
+      - run:
+          name: Go integration tests
+          env: GODEBUG=cgocheck=2
+          command: make test
       - run: make build-go
 
   test_alpine_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,10 @@ jobs:
       - run: cp /tmp/builds/libgo_cosmwasm.so ./api
       - run:
           name: Go integration tests
-          env: GODEBUG=cgocheck=2
           command: make test
+      - run:
+          name: Go tests with cgo and race condition safety checks
+          command: make test-safety
       - run: make build-go
 
   test_alpine_build:

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ build-go:
 test:
 	RUST_BACKTRACE=1 go test -v ./api ./types .
 
+test-safety:
+	GODEBUG=cgocheck=2 go test -race -v -count 1 ./api
+
 # we should build all the docker images locally ONCE and publish them
 docker-image-centos7:
 	docker build . -t cosmwasm/go-ext-builder:$(DOCKER_TAG)-centos7 -f ./Dockerfile.centos7

--- a/api/bindings.h
+++ b/api/bindings.h
@@ -64,7 +64,7 @@ typedef struct db_t {
   uint8_t _private[0];
 } db_t;
 
-typedef uint64_t iterator_t;
+typedef int64_t iterator_t;
 
 typedef struct Iterator_vtable {
   int32_t (*next_db)(iterator_t, gas_meter_t*, uint64_t*, Buffer*, Buffer*);

--- a/api/bindings.h
+++ b/api/bindings.h
@@ -64,17 +64,15 @@ typedef struct db_t {
   uint8_t _private[0];
 } db_t;
 
-typedef struct iterator_t {
-  uint8_t _private[0];
-} iterator_t;
+typedef uint64_t iterator_t;
 
 typedef struct Iterator_vtable {
-  int32_t (*next_db)(iterator_t*, gas_meter_t*, uint64_t*, Buffer*, Buffer*);
+  int32_t (*next_db)(iterator_t, gas_meter_t*, uint64_t*, Buffer*, Buffer*);
 } Iterator_vtable;
 
 typedef struct GoIter {
   gas_meter_t *gas_meter;
-  iterator_t *state;
+  iterator_t state;
   Iterator_vtable vtable;
 } GoIter;
 

--- a/api/bindings.h
+++ b/api/bindings.h
@@ -64,7 +64,10 @@ typedef struct db_t {
   uint8_t _private[0];
 } db_t;
 
-typedef int64_t iterator_t;
+typedef struct iterator_t {
+  uint64_t db_counter;
+  uint64_t iterator_index;
+} iterator_t;
 
 typedef struct Iterator_vtable {
   int32_t (*next_db)(iterator_t, gas_meter_t*, uint64_t*, Buffer*, Buffer*);

--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -27,6 +27,8 @@ GoResult cHumanAddress_cgo(api_t *ptr, Buffer canon, Buffer *human);
 GoResult cCanonicalAddress_cgo(api_t *ptr, Buffer human, Buffer *canon);
 // and querier
 GoResult cQueryExternal_cgo(querier_t *ptr, uint64_t *used_gas, Buffer request, Buffer *result);
+
+
 */
 import "C"
 
@@ -151,6 +153,7 @@ var iterator_vtable = C.Iterator_vtable{
 // since this is only used internally, we can verify the code that this is the case
 func buildIterator(dbCounter uint64, it dbm.Iterator, gasMeter *C.gas_meter_t) C.GoIter {
 	idx := storeIterator(dbCounter, it)
+	fmt.Println("buildIterator")
 	return C.GoIter{
 		gas_meter: gasMeter,
 		state: C.iterator_t{
@@ -264,7 +267,12 @@ func cScan(ptr *C.db_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, start C.Bu
 	gasAfter := gm.GasConsumed()
 	*usedGas = (C.uint64_t)((gasAfter - gasBefore) * GasMultiplier)
 
-	*out = buildIterator(state.Counter, iter, gasMeter)
+	res := buildIterator(state.Counter, iter, gasMeter)
+	out.state = res.state
+	fmt.Println("state written")
+	out.vtable = res.vtable
+	fmt.Println("vtable written")
+	fmt.Println("done!")
 	return C.GoResult_Ok
 }
 

--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -128,6 +128,10 @@ type DBState struct {
 	Counter uint64
 }
 
+// use this to create C.DB in two steps, so the pointer lives as long as the calling stack
+//   state := buildDBState(kv, counter)
+//   db := buildDB(&state, &gasMeter)
+//   // then pass db into some FFI function
 func buildDBState(kv KVStore, counter uint64) DBState {
 	return DBState{
 		Store:   kv,

--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -151,16 +151,11 @@ var iterator_vtable = C.Iterator_vtable{
 
 // contract: original pointer/struct referenced must live longer than C.DB struct
 // since this is only used internally, we can verify the code that this is the case
-func buildIterator(dbCounter uint64, it dbm.Iterator, gasMeter *C.gas_meter_t) C.GoIter {
+func buildIterator(dbCounter uint64, it dbm.Iterator) C.iterator_t {
 	idx := storeIterator(dbCounter, it)
-	fmt.Println("buildIterator")
-	return C.GoIter{
-		gas_meter: gasMeter,
-		state: C.iterator_t{
-			db_counter:     u64(dbCounter),
-			iterator_index: u64(idx),
-		},
-		vtable: iterator_vtable,
+	return C.iterator_t{
+		db_counter:     u64(dbCounter),
+		iterator_index: u64(idx),
 	}
 }
 
@@ -267,12 +262,8 @@ func cScan(ptr *C.db_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, start C.Bu
 	gasAfter := gm.GasConsumed()
 	*usedGas = (C.uint64_t)((gasAfter - gasBefore) * GasMultiplier)
 
-	res := buildIterator(state.Counter, iter, gasMeter)
-	out.state = res.state
-	fmt.Println("state written")
-	out.vtable = res.vtable
-	fmt.Println("vtable written")
-	fmt.Println("done!")
+	out.state = buildIterator(state.Counter, iter)
+	out.vtable = iterator_vtable
 	return C.GoResult_Ok
 }
 

--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -121,20 +121,15 @@ var db_vtable = C.DB_vtable{
 	scan_db:   (C.scan_db_fn)(C.cScan_cgo),
 }
 
-// this is a global counter when we create DBs
-// TODO: protect access (in buildDBState) via mutex
-var dbCounter uint64
-
 type DBState struct {
 	Store   KVStore
 	Counter uint64
 }
 
-func buildDBState(kv KVStore) DBState {
-	dbCounter += 1
+func buildDBState(kv KVStore, counter uint64) DBState {
 	return DBState{
 		Store:   kv,
-		Counter: dbCounter,
+		Counter: counter,
 	}
 }
 

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -1,0 +1,1 @@
+package api

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -35,7 +35,7 @@ func endContract() {
 // storeIterator will add this to the end of the latest stack and return a reference to it.
 // We start counting with 1, so the 0 value is flagged as an error. This means we must
 // remember to do idx-1 when retrieving
-func storeIterator(it dbm.Iterator) int {
+func storeIterator(dbCounter uint64, it dbm.Iterator) uint64 {
 	l := len(IteratorStack)
 	if l == 0 {
 		panic("cannot storeIterator with empty iterator stack")
@@ -49,7 +49,7 @@ func storeIterator(it dbm.Iterator) int {
 // retrieveIterator will recover an iterator based on index. This ensures it will not be garbage collected.
 // We start counting with 1, in storeIterator so the 0 value is flagged as an error. This means we must
 // remember to do idx-1 when retrieving
-func retrieveIterator(idx int) dbm.Iterator {
+func retrieveIterator(dbCounter uint64, index uint64) dbm.Iterator {
 	l := len(IteratorStack)
 	if l == 0 {
 		panic("cannot retrieveIterator with empty iterator stack")

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -1,1 +1,60 @@
 package api
+
+import (
+	"fmt"
+	dbm "github.com/tendermint/tm-db"
+)
+
+// This stores all Iterators for one contract
+type Iterators []dbm.Iterator
+
+// IteratorStack contains one entry for each contract, LIFO style
+var IteratorStack []Iterators
+
+// startContract is called at the beginning of a contract runtime to create a new item on the IteratorStack
+func startContract() {
+	IteratorStack = append(IteratorStack, nil)
+	// TODO: remove debug
+	fmt.Printf("startContract: Stack height: %d\n", len(IteratorStack))
+}
+
+// endContract is called at the end of a contract runtime to remove one item from the IteratorStack
+func endContract() {
+	l := len(IteratorStack)
+	var remove Iterators
+	IteratorStack, remove = IteratorStack[:l-1], IteratorStack[l-1]
+	// free all iterators we pop off the stack
+	for _, iter := range remove {
+		fmt.Printf("endContract: close iterator\n")
+		iter.Close()
+	}
+	// TODO: remove debug
+	fmt.Printf("endContract: Stack height: %d\n", len(IteratorStack))
+}
+
+// storeIterator will add this to the end of the latest stack and return a reference to it.
+// We start counting with 1, so the 0 value is flagged as an error. This means we must
+// remember to do idx-1 when retrieving
+func storeIterator(it dbm.Iterator) int {
+	l := len(IteratorStack)
+	if l == 0 {
+		panic("cannot storeIterator with empty iterator stack")
+	}
+	IteratorStack[l-1] = append(IteratorStack[l-1], it)
+	// TODO: remove debug
+	fmt.Printf("store iterator: height (idx): %d (%d)\n", len(IteratorStack), len(IteratorStack[l-1]))
+	return len(IteratorStack[l-1])
+}
+
+// retrieveIterator will recover an iterator based on index. This ensures it will not be garbage collected.
+// We start counting with 1, in storeIterator so the 0 value is flagged as an error. This means we must
+// remember to do idx-1 when retrieving
+func retrieveIterator(idx int) dbm.Iterator {
+	l := len(IteratorStack)
+	if l == 0 {
+		panic("cannot retrieveIterator with empty iterator stack")
+	}
+	// TODO: remove debug
+	fmt.Printf("retrieveIterator: height (idx/size): %d (%d/%d)\n", len(IteratorStack), idx, len(IteratorStack[l-1]))
+	return IteratorStack[l-1][idx-1]
+}

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -9,7 +9,8 @@ import (
 type frame []dbm.Iterator
 
 // iteratorStack contains one frame for each contract, indexed by a counter
-var iteratorStack = make(map[uint64]frame, 60)
+// 10 is a rather arbitrary guess on how many frames might be needed simultaneously
+var iteratorStack = make(map[uint64]frame, 10)
 var iteratorStackMutex sync.Mutex
 
 // this is a global counter when we create DBs

--- a/api/iterator.go
+++ b/api/iterator.go
@@ -3,21 +3,23 @@ package api
 import (
 	"fmt"
 	dbm "github.com/tendermint/tm-db"
+	"sync"
 )
 
 // frame stores all Iterators for one contract
 type frame []dbm.Iterator
 
 // iteratorStack contains one frame for each contract, indexed by a counter
-// TODO: protect access (in buildDBState) via mutex
 var iteratorStack = make(map[uint64]frame, 60)
+var iteratorStackMutex sync.Mutex
 
 // this is a global counter when we create DBs
-// TODO: protect access (in buildDBState) via mutex
 var dbCounter uint64
+var dbCounterMutex sync.Mutex
 
 func nextCounter() uint64 {
-	// TODO: add mutex
+	dbCounterMutex.Lock()
+	defer dbCounterMutex.Unlock()
 	dbCounter += 1
 	return dbCounter
 }
@@ -31,15 +33,22 @@ func startContract() uint64 {
 	return counter
 }
 
+func popFrame(counter uint64) frame {
+	iteratorStackMutex.Lock()
+	defer iteratorStackMutex.Unlock()
+	// get the item from the stack
+
+	remove := iteratorStack[counter]
+	delete(iteratorStack, counter)
+	return remove
+}
+
 // endContract is called at the end of a contract runtime to remove one item from the IteratorStack
 func endContract(counter uint64) {
 	// TODO: remove debug
 	fmt.Printf("endContract: remove frame: %d\n", counter)
 
-	// get the item from the stack
-	remove := iteratorStack[counter]
-	delete(iteratorStack, counter)
-
+	remove := popFrame(counter)
 	// free all iterators in the frame when we release it
 	for _, iter := range remove {
 		fmt.Printf("endContract: close iterator\n")
@@ -51,6 +60,9 @@ func endContract(counter uint64) {
 // We start counting with 1, so the 0 value is flagged as an error. This means we must
 // remember to do idx-1 when retrieving
 func storeIterator(dbCounter uint64, it dbm.Iterator) uint64 {
+	iteratorStackMutex.Lock()
+	defer iteratorStackMutex.Unlock()
+
 	frame := append(iteratorStack[dbCounter], it)
 	iteratorStack[dbCounter] = frame
 	index := len(frame)
@@ -63,6 +75,9 @@ func storeIterator(dbCounter uint64, it dbm.Iterator) uint64 {
 // We start counting with 1, in storeIterator so the 0 value is flagged as an error. This means we must
 // remember to do idx-1 when retrieving
 func retrieveIterator(dbCounter uint64, index uint64) dbm.Iterator {
+	iteratorStackMutex.Lock()
+	defer iteratorStackMutex.Unlock()
+
 	// TODO: remove debug
 	fmt.Printf("retrieveIterator: height (idx/size): %d (%d/%d)\n", dbCounter, index, len(iteratorStack[dbCounter]))
 	return iteratorStack[dbCounter][index-1]

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/CosmWasm/go-cosmwasm/types"
+)
+
+type queueData struct {
+	id      []byte
+	store   KVStore
+	api     *GoAPI
+	querier types.Querier
+}
+
+func setupQueueContract(t *testing.T, cache Cache) queueData {
+	id := createQueueContract(t, cache)
+
+	gasMeter1 := NewMockGasMeter(100000000)
+	// instantiate it with this store
+	store := NewLookup()
+	api := NewMockAPI()
+	querier := DefaultQuerier(mockContractAddr, types.Coins{types.NewCoin(100, "ATOM")})
+	params, err := json.Marshal(mockEnv(binaryAddr("creator")))
+	require.NoError(t, err)
+	msg := []byte(`{}`)
+
+	res, _, err := Instantiate(cache, id, params, msg, &gasMeter1, store, api, &querier, 100000000)
+	require.NoError(t, err)
+	requireOkResponse(t, res, 0)
+
+	// push 17
+	gasMeter2 := NewMockGasMeter(100000000)
+	push := []byte(`{"enqueue":{"value":17}}`)
+	res, _, err = Handle(cache, id, params, push, &gasMeter2, store, api, &querier, 100000000)
+	require.NoError(t, err)
+	requireOkResponse(t, res, 0)
+	// push 22
+	gasMeter3 := NewMockGasMeter(100000000)
+	push = []byte(`{"enqueue":{"value":22}}`)
+	res, _, err = Handle(cache, id, params, push, &gasMeter3, store, api, &querier, 100000000)
+	require.NoError(t, err)
+	requireOkResponse(t, res, 0)
+
+	return queueData{
+		id:      id,
+		store:   store,
+		api:     api,
+		querier: querier,
+	}
+
+}
+
+func TestQueueIterator(t *testing.T) {
+	cache, cleanup := withCache(t)
+	defer cleanup()
+
+	setup := setupQueueContract(t, cache)
+	id, store, querier, api := setup.id, setup.store, setup.querier, setup.api
+
+	// query the sum
+	gasMeter := NewMockGasMeter(100000000)
+	query := []byte(`{"sum":{}}`)
+	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
+	require.NoError(t, err)
+	var qres types.QueryResponse
+	err = json.Unmarshal(data, &qres)
+	require.NoError(t, err)
+	require.Nil(t, qres.Err, "%v", qres.Err)
+	require.Equal(t, string(qres.Ok), `{"sum":39}`)
+
+	// query reduce (multiple iterators at once)
+	query = []byte(`{"reducer":{}}`)
+	data, _, err = Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
+	require.NoError(t, err)
+	var reduced types.QueryResponse
+	err = json.Unmarshal(data, &reduced)
+	require.NoError(t, err)
+	require.Nil(t, reduced.Err, "%v", reduced.Err)
+	require.Equal(t, string(reduced.Ok), `{"counters":[[17,22],[22,0]]}`)
+}
+
+func TestQueueIteratorRaces(t *testing.T) {
+	cache, cleanup := withCache(t)
+	defer cleanup()
+
+	setup := setupQueueContract(t, cache)
+
+	reduceQuery := func(t *testing.T, setup queueData) {
+		id, store, querier, api := setup.id, setup.store, setup.querier, setup.api
+
+		// query reduce (multiple iterators at once)
+		query := []byte(`{"reducer":{}}`)
+		gasMeter := NewMockGasMeter(100000000)
+		data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
+		require.NoError(t, err)
+		var reduced types.QueryResponse
+		err = json.Unmarshal(data, &reduced)
+		require.NoError(t, err)
+		require.Nil(t, reduced.Err, "%v", reduced.Err)
+		require.Equal(t, string(reduced.Ok), `{"counters":[[17,22],[22,0]]}`)
+	}
+
+	numRoutines := 10
+
+	var wg sync.WaitGroup
+	wg.Add(numRoutines)
+	for i := 0; i < numRoutines; i++ {
+		go func() {
+			reduceQuery(t, setup)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+}

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -110,8 +110,8 @@ func TestQueueIteratorRaces(t *testing.T) {
 		require.Equal(t, string(reduced.Ok), fmt.Sprintf(`{"counters":%s}`, expected))
 	}
 
-	// 100 concurrent batches (in go routines) to trigger any race condition
-	numBatches := 100
+	// 30 concurrent batches (in go routines) to trigger any race condition
+	numBatches := 30
 
 	var wg sync.WaitGroup
 	// for each batch, query each of the 3 contracts - so the contract queries get mixed together

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
 
@@ -88,6 +89,8 @@ func TestQueueIteratorRaces(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()
 
+	assert.Equal(t, len(iteratorStack), 0)
+
 	setup := setupQueueContract(t, cache)
 
 	reduceQuery := func(t *testing.T, setup queueData) {
@@ -117,4 +120,6 @@ func TestQueueIteratorRaces(t *testing.T) {
 	}
 	wg.Wait()
 
+	// when they finish, we should have popped everything off the stack
+	assert.Equal(t, len(iteratorStack), 0)
 }

--- a/api/lib.go
+++ b/api/lib.go
@@ -83,16 +83,18 @@ func Instantiate(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	dbState := buildDBState(store)
+
+	// set up a new stack frame to handle iterators
+	counter := startContract()
+	defer endContract(counter)
+
+	dbState := buildDBState(store, counter)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
 
-	// set up a new stack frame to handle iterators
-	startContract()
-	defer endContract()
 	res, err := C.instantiate(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -118,16 +120,18 @@ func Handle(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	dbState := buildDBState(store)
+
+	// set up a new stack frame to handle iterators
+	counter := startContract()
+	defer endContract(counter)
+
+	dbState := buildDBState(store, counter)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
 
-	// set up a new stack frame to handle iterators
-	startContract()
-	defer endContract()
 	res, err := C.handle(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -153,16 +157,18 @@ func Migrate(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	dbState := buildDBState(store)
+
+	// set up a new stack frame to handle iterators
+	counter := startContract()
+	defer endContract(counter)
+
+	dbState := buildDBState(store, counter)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
 
-	// set up a new stack frame to handle iterators
-	startContract()
-	defer endContract()
 	res, err := C.migrate(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -185,16 +191,18 @@ func Query(
 	defer freeAfterSend(id)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	dbState := buildDBState(store)
+
+	// set up a new stack frame to handle iterators
+	counter := startContract()
+	defer endContract(counter)
+
+	dbState := buildDBState(store, counter)
 	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
 
-	// set up a new stack frame to handle iterators
-	startContract()
-	defer endContract()
 	res, err := C.query(cache.ptr, id, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.

--- a/api/lib.go
+++ b/api/lib.go
@@ -88,6 +88,10 @@ func Instantiate(
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
+
+	// set up a new stack frame to handle iterators
+	startContract()
+	defer endContract()
 	res, err := C.instantiate(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -118,6 +122,10 @@ func Handle(
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
+
+	// set up a new stack frame to handle iterators
+	startContract()
+	defer endContract()
 	res, err := C.handle(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -148,6 +156,10 @@ func Migrate(
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
+
+	// set up a new stack frame to handle iterators
+	startContract()
+	defer endContract()
 	res, err := C.migrate(cache.ptr, id, p, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.
@@ -175,6 +187,10 @@ func Query(
 	q := buildQuerier(querier)
 	var gasUsed u64
 	errmsg := C.Buffer{}
+
+	// set up a new stack frame to handle iterators
+	startContract()
+	defer endContract()
 	res, err := C.query(cache.ptr, id, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.

--- a/api/lib.go
+++ b/api/lib.go
@@ -72,7 +72,7 @@ func Instantiate(
 	params []byte,
 	msg []byte,
 	gasMeter *GasMeter,
-	store *KVStore,
+	store KVStore,
 	api *GoAPI,
 	querier *Querier,
 	gasLimit uint64,
@@ -83,7 +83,8 @@ func Instantiate(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+	dbState := buildDBState(store)
+	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
@@ -106,7 +107,7 @@ func Handle(
 	params []byte,
 	msg []byte,
 	gasMeter *GasMeter,
-	store *KVStore,
+	store KVStore,
 	api *GoAPI,
 	querier *Querier,
 	gasLimit uint64,
@@ -117,7 +118,8 @@ func Handle(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+	dbState := buildDBState(store)
+	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
@@ -140,7 +142,7 @@ func Migrate(
 	params []byte,
 	msg []byte,
 	gasMeter *GasMeter,
-	store *KVStore,
+	store KVStore,
 	api *GoAPI,
 	querier *Querier,
 	gasLimit uint64,
@@ -151,7 +153,8 @@ func Migrate(
 	defer freeAfterSend(p)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+	dbState := buildDBState(store)
+	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64
@@ -173,7 +176,7 @@ func Query(
 	code_id []byte,
 	msg []byte,
 	gasMeter *GasMeter,
-	store *KVStore,
+	store KVStore,
 	api *GoAPI,
 	querier *Querier,
 	gasLimit uint64,
@@ -182,7 +185,8 @@ func Query(
 	defer freeAfterSend(id)
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
-	db := buildDB(store, gasMeter)
+	dbState := buildDBState(store)
+	db := buildDB(&dbState, gasMeter)
 	a := buildAPI(api)
 	q := buildQuerier(querier)
 	var gasUsed u64

--- a/api/lib.go
+++ b/api/lib.go
@@ -203,6 +203,8 @@ func Query(
 	var gasUsed u64
 	errmsg := C.Buffer{}
 
+
+
 	res, err := C.query(cache.ptr, id, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.

--- a/api/lib.go
+++ b/api/lib.go
@@ -203,8 +203,6 @@ func Query(
 	var gasUsed u64
 	errmsg := C.Buffer{}
 
-
-
 	res, err := C.query(cache.ptr, id, m, db, a, q, u64(gasLimit), &gasUsed, &errmsg)
 	if err != nil && err.(syscall.Errno) != C.ErrnoValue_Success {
 		// Depending on the nature of the error, `gasUsed` will either have a meaningful value, or just 0.

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -114,7 +114,7 @@ func TestInstantiate(t *testing.T) {
 	require.NoError(t, err)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
 
-	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter, &store, api, &querier, 100000000)
+	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 	assert.Equal(t, uint64(0x11f57), cost)
@@ -143,7 +143,7 @@ func TestHandle(t *testing.T) {
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
 
 	start := time.Now()
-	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, &store, api, &querier, 100000000)
+	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, store, api, &querier, 100000000)
 	diff := time.Now().Sub(start)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
@@ -155,7 +155,7 @@ func TestHandle(t *testing.T) {
 	params, err = json.Marshal(mockEnv(binaryAddr("fred")))
 	require.NoError(t, err)
 	start = time.Now()
-	res, cost, err = Handle(cache, id, params, []byte(`{"release":{}}`), &gasMeter2, &store, api, &querier, 100000000)
+	res, cost, err = Handle(cache, id, params, []byte(`{"release":{}}`), &gasMeter2, store, api, &querier, 100000000)
 	diff = time.Now().Sub(start)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0x1c135), cost)
@@ -191,13 +191,13 @@ func TestMigrate(t *testing.T) {
 	require.NoError(t, err)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
 
-	res, _, err := Instantiate(cache, id, params, msg, &gasMeter, &store, api, &querier, 100000000)
+	res, _, err := Instantiate(cache, id, params, msg, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 
 	// verifier is fred
 	query := []byte(`{"verifier":{}}`)
-	data, _, err := Query(cache, id, query, &gasMeter, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)
@@ -209,11 +209,11 @@ func TestMigrate(t *testing.T) {
 	// we use the same code blob as we are testing hackatom self-migration
 	params, err = json.Marshal(mockEnv(binaryAddr("fred")))
 	require.NoError(t, err)
-	res, _, err = Migrate(cache, id, params, []byte(`{"verifier":"alice"}`), &gasMeter, &store, api, &querier, 100000000)
+	res, _, err = Migrate(cache, id, params, []byte(`{"verifier":"alice"}`), &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 
 	// should update verifier to alice
-	data, _, err = Query(cache, id, query, &gasMeter, &store, api, &querier, 100000000)
+	data, _, err = Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres2 types.QueryResponse
 	err = json.Unmarshal(data, &qres2)
@@ -235,7 +235,7 @@ func TestMultipleInstances(t *testing.T) {
 	params, err := json.Marshal(mockEnv(binaryAddr("regen")))
 	require.NoError(t, err)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
-	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, &store1, api, &querier, 100000000)
+	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, store1, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 	assert.Equal(t, uint64(0x11f57), cost)
@@ -246,7 +246,7 @@ func TestMultipleInstances(t *testing.T) {
 	params, err = json.Marshal(mockEnv(binaryAddr("chorus")))
 	require.NoError(t, err)
 	msg = []byte(`{"verifier": "mary", "beneficiary": "sue"}`)
-	res, cost, err = Instantiate(cache, id, params, msg, &gasMeter2, &store2, api, &querier, 100000000)
+	res, cost, err = Instantiate(cache, id, params, msg, &gasMeter2, store2, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 	assert.Equal(t, uint64(0x11f57), cost)
@@ -309,7 +309,7 @@ func exec(t *testing.T, cache Cache, id []byte, signer string, store KVStore, ap
 	gasMeter := NewMockGasMeter(100000000)
 	params, err := json.Marshal(mockEnv(binaryAddr(signer)))
 	require.NoError(t, err)
-	res, cost, err := Handle(cache, id, params, []byte(`{"release":{}}`), &gasMeter, &store, api, &querier, 100000000)
+	res, cost, err := Handle(cache, id, params, []byte(`{"release":{}}`), &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	assert.Equal(t, gas, cost)
 
@@ -332,13 +332,13 @@ func TestQuery(t *testing.T) {
 	params, err := json.Marshal(mockEnv(binaryAddr("creator")))
 	require.NoError(t, err)
 	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
-	_, _, err = Instantiate(cache, id, params, msg, &gasMeter1, &store, api, &querier, 100000000)
+	_, _, err = Instantiate(cache, id, params, msg, &gasMeter1, store, api, &querier, 100000000)
 	require.NoError(t, err)
 
 	// invalid query
 	gasMeter2 := NewMockGasMeter(100000000)
 	query := []byte(`{"Raw":{"val":"config"}}`)
-	data, _, err := Query(cache, id, query, &gasMeter2, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter2, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var badResp types.QueryResponse
 	err = json.Unmarshal(data, &badResp)
@@ -353,7 +353,7 @@ func TestQuery(t *testing.T) {
 	// make a valid query
 	gasMeter3 := NewMockGasMeter(100000000)
 	query = []byte(`{"verifier":{}}`)
-	data, _, err = Query(cache, id, query, &gasMeter3, &store, api, &querier, 100000000)
+	data, _, err = Query(cache, id, query, &gasMeter3, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)
@@ -376,27 +376,27 @@ func TestQueueIterator(t *testing.T) {
 	require.NoError(t, err)
 	msg := []byte(`{}`)
 
-	res, _, err := Instantiate(cache, id, params, msg, &gasMeter1, &store, api, &querier, 100000000)
+	res, _, err := Instantiate(cache, id, params, msg, &gasMeter1, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 
 	// push 17
 	gasMeter2 := NewMockGasMeter(100000000)
 	push := []byte(`{"enqueue":{"value":17}}`)
-	res, _, err = Handle(cache, id, params, push, &gasMeter2, &store, api, &querier, 100000000)
+	res, _, err = Handle(cache, id, params, push, &gasMeter2, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 	// push 22
 	gasMeter3 := NewMockGasMeter(100000000)
 	push = []byte(`{"enqueue":{"value":22}}`)
-	res, _, err = Handle(cache, id, params, push, &gasMeter3, &store, api, &querier, 100000000)
+	res, _, err = Handle(cache, id, params, push, &gasMeter3, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 
 	// query the sum
 	gasMeter4 := NewMockGasMeter(100000000)
 	query := []byte(`{"sum":{}}`)
-	data, _, err := Query(cache, id, query, &gasMeter4, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter4, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)
@@ -407,7 +407,7 @@ func TestQueueIterator(t *testing.T) {
 	// query reduce (multiple iterators at once)
 	gasMeter5 := NewMockGasMeter(100000000)
 	query = []byte(`{"reducer":{}}`)
-	data, _, err = Query(cache, id, query, &gasMeter5, &store, api, &querier, 100000000)
+	data, _, err = Query(cache, id, query, &gasMeter5, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var reduced types.QueryResponse
 	err = json.Unmarshal(data, &reduced)
@@ -431,7 +431,7 @@ func TestHackatomQuerier(t *testing.T) {
 	// make a valid query to the other address
 	query := []byte(`{"other_balance":{"address":"foobar"}}`)
 	// TODO The query happens before the contract is initialized. How is this legal?
-	data, _, err := Query(cache, id, query, &gasMeter, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)
@@ -460,7 +460,7 @@ func TestCustomReflectQuerier(t *testing.T) {
 
 	// make a valid query to the other address
 	query := []byte(`{"reflect_custom":{"text":"small Frys :)"}}`)
-	data, _, err := Query(cache, id, query, &gasMeter, &store, api, &querier, 100000000)
+	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	var qres types.QueryResponse
 	err = json.Unmarshal(data, &qres)

--- a/lib.go
+++ b/lib.go
@@ -95,7 +95,7 @@ func (w *Wasmer) Instantiate(
 	if err != nil {
 		return nil, 0, err
 	}
-	data, gasUsed, err := api.Instantiate(w.cache, code, paramBin, initMsg, &gasMeter, &store, &goapi, &querier, gasLimit)
+	data, gasUsed, err := api.Instantiate(w.cache, code, paramBin, initMsg, &gasMeter, store, &goapi, &querier, gasLimit)
 	if err != nil {
 		return nil, gasUsed, err
 	}
@@ -131,7 +131,7 @@ func (w *Wasmer) Execute(
 	if err != nil {
 		return nil, 0, err
 	}
-	data, gasUsed, err := api.Handle(w.cache, code, paramBin, executeMsg, &gasMeter, &store, &goapi, &querier, gasLimit)
+	data, gasUsed, err := api.Handle(w.cache, code, paramBin, executeMsg, &gasMeter, store, &goapi, &querier, gasLimit)
 	if err != nil {
 		return nil, gasUsed, err
 	}
@@ -159,7 +159,7 @@ func (w *Wasmer) Query(
 	gasMeter api.GasMeter,
 	gasLimit uint64,
 ) ([]byte, uint64, error) {
-	data, gasUsed, err := api.Query(w.cache, code, queryMsg, &gasMeter, &store, &goapi, &querier, gasLimit)
+	data, gasUsed, err := api.Query(w.cache, code, queryMsg, &gasMeter, store, &goapi, &querier, gasLimit)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -195,7 +195,7 @@ func (w *Wasmer) Migrate(
 	if err != nil {
 		return nil, 0, err
 	}
-	data, gasUsed, err := api.Migrate(w.cache, code, paramBin, migrateMsg, &gasMeter, &store, &goapi, &querier, gasLimit)
+	data, gasUsed, err := api.Migrate(w.cache, code, paramBin, migrateMsg, &gasMeter, store, &goapi, &querier, gasLimit)
 	if err != nil {
 		return nil, gasUsed, err
 	}

--- a/src/db.rs
+++ b/src/db.rs
@@ -21,7 +21,7 @@ pub struct DB_vtable {
     pub remove_db: extern "C" fn(*mut db_t, *mut gas_meter_t, *mut u64, Buffer) -> i32,
     // order -> Ascending = 1, Descending = 2
     // Note: we cannot set gas_meter on the returned GoIter due to cgo memory safety.
-    // Since we have the pointer in rust already, we must set than manually
+    // Since we have the pointer in rust already, we must set that manually
     pub scan_db: extern "C" fn(
         *mut db_t,
         *mut gas_meter_t,

--- a/src/db.rs
+++ b/src/db.rs
@@ -20,6 +20,8 @@ pub struct DB_vtable {
     pub write_db: extern "C" fn(*mut db_t, *mut gas_meter_t, *mut u64, Buffer, Buffer) -> i32,
     pub remove_db: extern "C" fn(*mut db_t, *mut gas_meter_t, *mut u64, Buffer) -> i32,
     // order -> Ascending = 1, Descending = 2
+    // Note: we cannot set gas_meter on the returned GoIter due to cgo memory safety.
+    // Since we have the pointer in rust already, we must set than manually
     pub scan_db: extern "C" fn(
         *mut db_t,
         *mut gas_meter_t,
@@ -86,7 +88,7 @@ impl ReadonlyStorage for DB {
         let end_buf = end
             .map(|e| Buffer::from_vec(e.to_vec()))
             .unwrap_or_default();
-        let mut iter = GoIter::default();
+        let mut iter = GoIter::new(self.gas_meter);
         let mut used_gas = 0_u64;
         let go_result: GoResult = (self.vtable.scan_db)(
             self.state,

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -5,9 +5,13 @@ use crate::error::GoResult;
 use crate::gas_meter::gas_meter_t;
 use crate::memory::Buffer;
 
-// iterator is now a simple number (index to pointer on Go side)
-#[allow(non_camel_case_types)]
-pub type iterator_t = i64;
+// Iterator maintains integer references to some tables on the Go side
+#[repr(C)]
+#[derive(Default, Copy, Clone)]
+pub struct iterator_t {
+    pub db_counter: u64,
+    pub iterator_index: u64,
+}
 
 // These functions should return GoResult but because we don't trust them here, we treat the return value as i32
 // and then check it when converting to GoResult manually
@@ -30,7 +34,7 @@ impl Default for GoIter {
     fn default() -> Self {
         GoIter {
             gas_meter: std::ptr::null_mut(),
-            state: 0,
+            state: iterator_t::default(),
             vtable: Iterator_vtable::default(),
         }
     }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -30,10 +30,10 @@ pub struct GoIter {
     pub vtable: Iterator_vtable,
 }
 
-impl Default for GoIter {
-    fn default() -> Self {
+impl GoIter {
+    pub fn new(gas_meter: *mut gas_meter_t) -> Self {
         GoIter {
-            gas_meter: std::ptr::null_mut(),
+            gas_meter: gas_meter,
             state: iterator_t::default(),
             vtable: Iterator_vtable::default(),
         }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -7,7 +7,7 @@ use crate::memory::Buffer;
 
 // iterator is now a simple number (index to pointer on Go side)
 #[allow(non_camel_case_types)]
-pub type iterator_t = u64;
+pub type iterator_t = i64;
 
 // These functions should return GoResult but because we don't trust them here, we treat the return value as i32
 // and then check it when converting to GoResult manually
@@ -30,7 +30,7 @@ impl Default for GoIter {
     fn default() -> Self {
         GoIter {
             gas_meter: std::ptr::null_mut(),
-            state: 0_u64,
+            state: 0,
             vtable: Iterator_vtable::default(),
         }
     }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -33,7 +33,7 @@ pub struct GoIter {
 impl GoIter {
     pub fn new(gas_meter: *mut gas_meter_t) -> Self {
         GoIter {
-            gas_meter: gas_meter,
+            gas_meter,
             state: iterator_t::default(),
             vtable: Iterator_vtable::default(),
         }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -5,11 +5,9 @@ use crate::error::GoResult;
 use crate::gas_meter::gas_meter_t;
 use crate::memory::Buffer;
 
-// this represents something passed in from the caller side of FFI
-#[repr(C)]
-pub struct iterator_t {
-    _private: [u8; 0],
-}
+// iterator is now a simple number (index to pointer on Go side)
+#[allow(non_camel_case_types)]
+pub type iterator_t = u64;
 
 // These functions should return GoResult but because we don't trust them here, we treat the return value as i32
 // and then check it when converting to GoResult manually
@@ -17,14 +15,14 @@ pub struct iterator_t {
 #[derive(Default)]
 pub struct Iterator_vtable {
     pub next_db: Option<
-        extern "C" fn(*mut iterator_t, *mut gas_meter_t, *mut u64, *mut Buffer, *mut Buffer) -> i32,
+        extern "C" fn(iterator_t, *mut gas_meter_t, *mut u64, *mut Buffer, *mut Buffer) -> i32,
     >,
 }
 
 #[repr(C)]
 pub struct GoIter {
     pub gas_meter: *mut gas_meter_t,
-    pub state: *mut iterator_t,
+    pub state: iterator_t,
     pub vtable: Iterator_vtable,
 }
 
@@ -32,7 +30,7 @@ impl Default for GoIter {
     fn default() -> Self {
         GoIter {
             gas_meter: std::ptr::null_mut(),
-            state: std::ptr::null_mut(),
+            state: 0_u64,
             vtable: Iterator_vtable::default(),
         }
     }


### PR DESCRIPTION
Closes #95

This creates a global `IteratorStack` on the go side of go-cosmwasm that holds all iterators, which ensures they are not garbage collected. We just pass a reference to them (int index) over the FFI, which we look up on callbacks.

We create a new stack frame on each call and remove it (and close all iterators) when it closes. Thus if I call Handle, which calls out to Query, that will have it's own stack frame (for the queried contract) which will be cleaned up before returning to the Handle method.

This currently passes the tests (which include queue contract which opens up to 3 different iterators). However, we don't have tests doing nested calls (yet)

TODO:
- [x] Remove debug statements (run `make build-rust; make test` and see the stack info)
- [x] Handle multi-threaded issues (race conditions)

----

Update: I implemented #2 below after some investigation (in the comments below)

Note that mutable globals are dangerous and usually require mutexes to be safe. However, we are running in a single-threaded environment, which should make this safe. Well... not really  :bomb: 

All *transactions* run in one thread, but there is a query thread running in parallel to handle external queries off the last committed state. We must make this robust against this race condition. We cannot strictly separate Query and Handle calls, as some Query calls are dispatched as part of the transaction processing. 

Possible solutions:
1. We keep this IteratorStack as a thread-local (actually go-routine local), which is only supported by some odd low-level fiddling: https://github.com/jtolio/gls
2. We store a unique identifier in `C.DB` when we create it. When calling cScan, we pull this out and use that to determine the stack frame to add to. The iterator_id is then a combination of this "db id" (stack frame) and an index in that frame.
3. Something else I have not thought of.