### PR TITLE
Remove init data

### DIFF
--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -119,7 +119,7 @@ func TestInstantiate(t *testing.T) {
 	requireOkResponse(t, res, 0)
 	assert.Equal(t, uint64(0x11f57), cost)
 
-	var resp types.CosmosResponse
+	var resp types.InitResult
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
 	require.Nil(t, resp.Err)
@@ -162,7 +162,7 @@ func TestHandle(t *testing.T) {
 	fmt.Printf("Time (%d gas): %s\n", cost, diff)
 
 	// make sure it read the balance properly and we got 250 atoms
-	var resp types.CosmosResponse
+	var resp types.HandleResult
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
 	require.Nil(t, resp.Err)
@@ -277,7 +277,7 @@ func TestMultipleInstances(t *testing.T) {
 }
 
 func requireOkResponse(t *testing.T, res []byte, expectedMsgs int) {
-	var resp types.CosmosResponse
+	var resp types.HandleResult
 	err := json.Unmarshal(res, &resp)
 	require.NoError(t, err)
 	require.Nil(t, resp.Err, "%v", resp.Err)
@@ -305,7 +305,7 @@ func createContract(t *testing.T, cache Cache, wasmFile string) []byte {
 }
 
 // exec runs the handle tx with the given signer
-func exec(t *testing.T, cache Cache, id []byte, signer string, store KVStore, api *GoAPI, querier Querier, gas uint64) types.CosmosResponse {
+func exec(t *testing.T, cache Cache, id []byte, signer string, store KVStore, api *GoAPI, querier Querier, gas uint64) types.HandleResult {
 	gasMeter := NewMockGasMeter(100000000)
 	params, err := json.Marshal(mockEnv(binaryAddr(signer)))
 	require.NoError(t, err)
@@ -313,7 +313,7 @@ func exec(t *testing.T, cache Cache, id []byte, signer string, store KVStore, ap
 	require.NoError(t, err)
 	assert.Equal(t, gas, cost)
 
-	var resp types.CosmosResponse
+	var resp types.HandleResult
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
 	return resp

--- a/lib.go
+++ b/lib.go
@@ -90,7 +90,7 @@ func (w *Wasmer) Instantiate(
 	querier Querier,
 	gasMeter api.GasMeter,
 	gasLimit uint64,
-) (*types.Result, uint64, error) {
+) (*types.InitResponse, uint64, error) {
 	paramBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -100,7 +100,7 @@ func (w *Wasmer) Instantiate(
 		return nil, gasUsed, err
 	}
 
-	var resp types.CosmosResponse
+	var resp types.InitResult
 	err = json.Unmarshal(data, &resp)
 	if err != nil {
 		return nil, gasUsed, err
@@ -126,7 +126,7 @@ func (w *Wasmer) Execute(
 	querier Querier,
 	gasMeter api.GasMeter,
 	gasLimit uint64,
-) (*types.Result, uint64, error) {
+) (*types.HandleResponse, uint64, error) {
 	paramBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -136,7 +136,7 @@ func (w *Wasmer) Execute(
 		return nil, gasUsed, err
 	}
 
-	var resp types.CosmosResponse
+	var resp types.HandleResult
 	err = json.Unmarshal(data, &resp)
 	if err != nil {
 		return nil, gasUsed, err
@@ -181,7 +181,16 @@ func (w *Wasmer) Query(
 // the given data.
 //
 // MigrateMsg has some data on how to perform the migration.
-func (w *Wasmer) Migrate(code CodeID, env types.Env, migrateMsg []byte, store KVStore, goapi GoAPI, querier Querier, gasMeter api.GasMeter, gasLimit uint64) (*types.Result, uint64, error) {
+func (w *Wasmer) Migrate(
+	code CodeID,
+	env types.Env,
+	migrateMsg []byte,
+	store KVStore,
+	goapi GoAPI,
+	querier Querier,
+	gasMeter api.GasMeter,
+	gasLimit uint64,
+) (*types.MigrateResponse, uint64, error) {
 	paramBin, err := json.Marshal(env)
 	if err != nil {
 		return nil, 0, err
@@ -191,7 +200,7 @@ func (w *Wasmer) Migrate(code CodeID, env types.Env, migrateMsg []byte, store KV
 		return nil, gasUsed, err
 	}
 
-	var resp types.CosmosResponse
+	var resp types.MigrateResult
 	err = json.Unmarshal(data, &resp)
 	if err != nil {
 		return nil, gasUsed, err

--- a/types/msg.go
+++ b/types/msg.go
@@ -6,14 +6,44 @@ import (
 
 //------- Results / Msgs -------------
 
-// CosmosResponse is the raw response from the init / handle calls
-type CosmosResponse struct {
-	Ok  *Result   `json:"Ok,omitempty"`
-	Err *StdError `json:"Err,omitempty"`
+// HandleResult is the raw response from the handle call
+type HandleResult struct {
+	Ok  *HandleResponse `json:"Ok,omitempty"`
+	Err *StdError       `json:"Err,omitempty"`
 }
 
-// Result defines the return value on a successful
-type Result struct {
+// HandleResponse defines the return value on a successful handle
+type HandleResponse struct {
+	// Messages comes directly from the contract and is it's request for action
+	Messages []CosmosMsg `json:"messages"`
+	// base64-encoded bytes to return as ABCI.Data field
+	Data string `json:"data"`
+	// log message to return over abci interface
+	Log []LogAttribute `json:"log"`
+}
+
+// InitResult is the raw response from the handle call
+type InitResult struct {
+	Ok  *InitResponse `json:"Ok,omitempty"`
+	Err *StdError     `json:"Err,omitempty"`
+}
+
+// InitResponse defines the return value on a successful handle
+type InitResponse struct {
+	// Messages comes directly from the contract and is it's request for action
+	Messages []CosmosMsg `json:"messages"`
+	// log message to return over abci interface
+	Log []LogAttribute `json:"log"`
+}
+
+// MigrateResult is the raw response from the handle call
+type MigrateResult struct {
+	Ok  *MigrateResponse `json:"Ok,omitempty"`
+	Err *StdError        `json:"Err,omitempty"`
+}
+
+// MigrateResponse defines the return value on a successful handle
+type MigrateResponse struct {
 	// Messages comes directly from the contract and is it's request for action
 	Messages []CosmosMsg `json:"messages"`
 	// base64-encoded bytes to return as ABCI.Data field


### PR DESCRIPTION
Closes #104 

Renames the return types (`Result<Response, Error>`) and provide different ones for handle, init, and migrate as we do in CosmWasm now.

Also remove the data field from the InitResponse.