### PR TITLE
Fix cpu loop issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.1"
+version = "0.9.0-alpha3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a794646cd6fc511662a958954a1c32a2a6b5b6a6db075f347130ae7d3cbfa567"
+checksum = "3f965fb27c94e5e60720f953f84e4814627c67410b732b66a09c64e436c8e0a0"
 dependencies = [
  "base64",
  "schemars",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.9.1"
+version = "0.9.0-alpha3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6a9d8b668046dbab204cd4c5996f1f38f94b3a5a3042d35d264cc4efdb60c4"
+checksum = "24795a6e3c6577d10d7ffbc3c4ecb305588ce88253ef8d19cf7301f0b3f30079"
 dependencies = [
  "cosmwasm-std",
  "hex",
@@ -1070,9 +1070,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasmer-clif-backend"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2fae69b1c7429316cad6743f3d2ca83cf8957924c477c5a4eff036ec0097a9"
+checksum = "691ea323652d540a10722066dbf049936f4367bb22a96f8992a262a942a8b11b"
 dependencies = [
  "byteorder",
  "cranelift-codegen",
@@ -1122,18 +1122,18 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middleware-common"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e70825a14d100994af1d9a347591c80dea1000f2b8e455a5712c2cc23ef08d"
+checksum = "fd94068186b25fbe5213442648ffe0fa65ee77389bed020404486fd22056cc87"
 dependencies = [
  "wasmer-runtime-core",
 ]
 
 [[package]]
 name = "wasmer-runtime-core"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740161245998752cf1a567e860fd6355df0336fedca6be1940ec7aaa59643220"
+checksum = "45d4253f097502423d8b19d54cb18745f61b984b9dbce32424cba7945cfef367"
 dependencies = [
  "bincode",
  "blake3",
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-singlepass-backend"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a434ebf512ae1c76de46d41935a9ae10775fd937071334bdf5878cc41d9140"
+checksum = "37cf84179dd5e92b784f7bc190b237f1184916a6d6d3f87d4dd94ca371a2cc25"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-win-exception-handler"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd39f3b2bd7964b28ea6f944a7eaa445cfbc91c4f2695d188103f2689bb37d9"
+checksum = "cf22ce6dc66d893099aac853d451bf9443fa8f5443f5bf4fc63f3aebd7b592b1"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,8 +464,10 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-vm",
  "errno",
+ "serde",
  "serde_json",
  "snafu",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 cranelift = ["cosmwasm-vm/default-cranelift"]
 
 [dependencies]
-cosmwasm-std = { version = "0.9.1", features = ["iterator"]}
-cosmwasm-vm = { version = "0.9.1", features = ["iterator"] }
+cosmwasm-std = { version = "0.9.0-alpha3", features = ["iterator"]}
+cosmwasm-vm = { version = "0.9.0-alpha3", features = ["iterator"] }
 errno = "0.2"
 snafu = "0.6.3"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ errno = "0.2"
 snafu = "0.6.3"
 serde_json = "1.0"
 
+[dev-dependencies]
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+tempfile = "3.1.0"
+
 [build-dependencies]
 cbindgen = { version = "0.14" }
 

--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -104,6 +104,8 @@ type KVStore interface {
 	Set(key, value []byte)
 	Delete(key []byte)
 
+
+
 	// Iterator over a domain of keys in ascending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
 	// Iterator must be closed by caller.

--- a/api/lib.go
+++ b/api/lib.go
@@ -192,6 +192,7 @@ func Query(
 	m := sendSlice(msg)
 	defer freeAfterSend(m)
 
+
 	// set up a new stack frame to handle iterators
 	counter := startContract()
 	defer endContract(counter)

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -204,12 +204,12 @@ func TestHandleCpuLoop(t *testing.T) {
 	fmt.Printf("Time (%d gas): %s\n", 0xbb66, diff)
 
 	// execute a cpu loop
-	maxGas := uint64(40_000)
+	maxGas := uint64(40_000_000)
 	gasMeter2 := NewMockGasMeter(maxGas)
 	params, err = json.Marshal(mockEnv(binaryAddr("fred")))
 	require.NoError(t, err)
 	start = time.Now()
-	res, cost, err = Handle(cache, id, params, []byte(`{"cpu_loop":{}}`), &gasMeter2, store, api, &querier, 40_000)
+	res, cost, err = Handle(cache, id, params, []byte(`{"cpu_loop":{}}`), &gasMeter2, store, api, &querier, maxGas)
 	diff = time.Now().Sub(start)
 	require.Error(t, err)
 	assert.Equal(t, cost, maxGas)

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -179,6 +179,43 @@ func TestHandle(t *testing.T) {
 	assert.Equal(t, expectedData, resp.Ok.Data)
 }
 
+func TestHandleCpuLoop(t *testing.T) {
+	cache, cleanup := withCache(t)
+	defer cleanup()
+	id := createTestContract(t, cache)
+
+	gasMeter1 := NewMockGasMeter(100000000)
+	// instantiate it with this store
+	store := NewLookup()
+	api := NewMockAPI()
+	balance := types.Coins{types.NewCoin(250, "ATOM")}
+	querier := DefaultQuerier(mockContractAddr, balance)
+	params, err := json.Marshal(mockEnv(binaryAddr("creator")))
+	require.NoError(t, err)
+
+	msg := []byte(`{"verifier": "fred", "beneficiary": "bob"}`)
+
+	start := time.Now()
+	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter1, store, api, &querier, 100000000)
+	diff := time.Now().Sub(start)
+	require.NoError(t, err)
+	requireOkResponse(t, res, 0)
+	assert.Equal(t, uint64(0x1348a), cost)
+	fmt.Printf("Time (%d gas): %s\n", 0xbb66, diff)
+
+	// execute a cpu loop
+	maxGas := uint64(40_000)
+	gasMeter2 := NewMockGasMeter(maxGas)
+	params, err = json.Marshal(mockEnv(binaryAddr("fred")))
+	require.NoError(t, err)
+	start = time.Now()
+	res, cost, err = Handle(cache, id, params, []byte(`{"cpu_loop":{}}`), &gasMeter2, store, api, &querier, 40_000)
+	diff = time.Now().Sub(start)
+	require.Error(t, err)
+	assert.Equal(t, cost, maxGas)
+	fmt.Printf("CPULoop Time (%d gas): %s\n", cost, diff)
+}
+
 func TestMigrate(t *testing.T) {
 	cache, cleanup := withCache(t)
 	defer cleanup()

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 use std::env;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-    cbindgen::generate(crate_dir)
-        .expect("Unable to generate bindings")
-        .write_to_file("./api/bindings.h");
+        cbindgen::generate(crate_dir)
+            .expect("Unable to generate bindings")
+            .write_to_file("./api/bindings.h");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 use std::env;
 
 fn main() {
-        let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
-        cbindgen::generate(crate_dir)
-            .expect("Unable to generate bindings")
-            .write_to_file("./api/bindings.h");
+    cbindgen::generate(crate_dir)
+        .expect("Unable to generate bindings")
+        .write_to_file("./api/bindings.h");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod gas_meter;
 mod iterator;
 mod memory;
 mod querier;
+mod tests;
 
 pub use api::GoApi;
 pub use db::{db_t, DB};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,7 +28,6 @@ fn make_init_msg() -> (InitMsg, HumanAddr) {
     )
 }
 
-#[ignore]
 #[test]
 fn handle_cpu_loop_with_cache() {
     let deps = mock_dependencies(20, &[]);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,64 @@
+#![cfg(test)]
+
+use serde::{Deserialize, Serialize};
+use tempfile::TempDir;
+
+use cosmwasm_std::{coins, HumanAddr};
+use cosmwasm_vm::testing::{mock_dependencies, mock_env};
+use cosmwasm_vm::{call_handle_raw, call_init_raw, features_from_csv, to_vec, CosmCache};
+
+static CONTRACT: &[u8] = include_bytes!("../api/testdata/hackatom.wasm");
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct InitMsg {
+    pub verifier: HumanAddr,
+    pub beneficiary: HumanAddr,
+}
+
+fn make_init_msg() -> (InitMsg, HumanAddr) {
+    let verifier = HumanAddr::from("verifies");
+    let beneficiary = HumanAddr::from("benefits");
+    let creator = HumanAddr::from("creator");
+    (
+        InitMsg {
+            verifier: verifier.clone(),
+            beneficiary: beneficiary.clone(),
+        },
+        creator,
+    )
+}
+
+#[test]
+fn handle_cpu_loop() {
+    let deps = mock_dependencies(20, &[]);
+    let gas_limit = 2_000_000u64;
+
+    let tmp_dir = TempDir::new().unwrap();
+    let features = features_from_csv("staking");
+    let mut cache = unsafe { CosmCache::new(tmp_dir.path(), features, 0) }.unwrap();
+
+    // store code
+    let code_id = cache.save_wasm(CONTRACT).unwrap();
+
+    // init
+    let (init_msg, creator) = make_init_msg();
+    let env = mock_env(&deps.api, creator.as_str(), &coins(1000, "cosm"));
+    let mut instance = cache.get_instance(&code_id, deps, gas_limit).unwrap();
+    let raw_msg = to_vec(&init_msg).unwrap();
+    let raw_env = to_vec(&env).unwrap();
+    let res = call_init_raw(&mut instance, &raw_env, &raw_msg);
+    let gas_used = gas_limit - instance.get_gas_left();
+    println!("Init used gas: {}", gas_used);
+    res.unwrap();
+    let deps = instance.recycle().unwrap();
+
+    // handle
+    let mut instance = cache.get_instance(&code_id, deps, gas_limit).unwrap();
+    let raw_msg = r#"{"cpu_loop":{}}"#;
+    let res = call_handle_raw(&mut instance, &raw_env, raw_msg.as_bytes());
+    let gas_used = gas_limit - instance.get_gas_left();
+    println!("Handle used gas: {}", gas_used);
+    assert!(res.is_err());
+    assert_eq!(instance.get_gas_left(), 0);
+    instance.recycle();
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 
 use cosmwasm_std::{coins, HumanAddr};
-use cosmwasm_vm::testing::{mock_dependencies, mock_env};
+use cosmwasm_vm::testing::{mock_dependencies, mock_env, mock_instance_with_gas_limit};
 use cosmwasm_vm::{call_handle_raw, call_init_raw, features_from_csv, to_vec, CosmCache};
 
 static CONTRACT: &[u8] = include_bytes!("../api/testdata/hackatom.wasm");
@@ -28,8 +28,9 @@ fn make_init_msg() -> (InitMsg, HumanAddr) {
     )
 }
 
+#[ignore]
 #[test]
-fn handle_cpu_loop() {
+fn handle_cpu_loop_with_cache() {
     let deps = mock_dependencies(20, &[]);
     let gas_limit = 2_000_000u64;
 
@@ -61,4 +62,28 @@ fn handle_cpu_loop() {
     assert!(res.is_err());
     assert_eq!(instance.get_gas_left(), 0);
     instance.recycle();
+}
+
+#[test]
+fn handle_cpu_loop_no_cache() {
+    let gas_limit = 2_000_000u64;
+    let mut instance = mock_instance_with_gas_limit(CONTRACT, gas_limit);
+
+    // init
+    let (init_msg, creator) = make_init_msg();
+    let env = mock_env(&instance.api, creator.as_str(), &coins(1000, "cosm"));
+    let raw_msg = to_vec(&init_msg).unwrap();
+    let raw_env = to_vec(&env).unwrap();
+    let res = call_init_raw(&mut instance, &raw_env, &raw_msg);
+    let gas_used = gas_limit - instance.get_gas_left();
+    println!("Init used gas: {}", gas_used);
+    res.unwrap();
+
+    // handle
+    let raw_msg = r#"{"cpu_loop":{}}"#;
+    let res = call_handle_raw(&mut instance, &raw_env, raw_msg.as_bytes());
+    let gas_used = gas_limit - instance.get_gas_left();
+    println!("Handle used gas: {}", gas_used);
+    assert!(res.is_err());
+    assert_eq!(instance.get_gas_left(), 0);
 }


### PR DESCRIPTION
Experiments where the issue comes from. This allowed infinite loops in wasmd.

**Update:**
I got this working by reverting to `v0.9.0-alpha3` of cosmwasm. I will merge this in (all tests and the version reversion) and tag it as something stable. Another follow up PR can try to safely update cosmwasm-vm dependency, but now has solid tests to catch any errors.

-----

I reproduced it in go-cosmwasm go tests. (run `make test`)

Then I reproduced it was go-cosmwasm rust tests (currently disabled) - (run `cargo test` after enabling)

```
#[ignore]
#[test]
fn handle_cpu_loop_with_cache() {
```

Then I wrote similar code that was very close to the failing rust loop, but never serializing the wasm to the CosmWasm... and it worked!

Something is fishy the gas metering and CosmCache.
