### PR TITLE
Verify proper gas charges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b160c8e594deaf23599bfd20b38961d8b122b7218e8f30c8943590037d1b58"
+checksum = "ecadad4858cac51d891d00206910886637ef0f56c05e16e1d4b611bca4338d68"
 dependencies = [
  "base64",
  "schemars",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-vm"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c85a72315aea7e8d500c37b9db01d8feeee7ebdf5213d55d4af60c3af09b14f"
+checksum = "0407aac6c2cebc277ddabb88316b00e7ac3b2bfea2716d15aec7f049e7ae8407"
 dependencies = [
  "cosmwasm-std",
  "hex",
@@ -458,7 +458,7 @@ checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "go-cosmwasm"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "cbindgen",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-cosmwasm"
-version = "0.9.2"
+version = "0.9.4"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Go bindings for cosmwasm contracts"
@@ -31,8 +31,8 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 cranelift = ["cosmwasm-vm/default-cranelift"]
 
 [dependencies]
-cosmwasm-std = { version = "0.9.2", features = ["iterator"]}
-cosmwasm-vm = { version = "0.9.2", features = ["iterator"] }
+cosmwasm-std = { version = "0.9.4", features = ["iterator"]}
+cosmwasm-vm = { version = "0.9.4", features = ["iterator"] }
 errno = "0.2"
 snafu = "0.6.3"
 serde_json = "1.0"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -23,7 +23,7 @@ func TestCanonicalAddressFailure(t *testing.T) {
 
 	gasMeter := NewMockGasMeter(100000000)
 	// instantiate it with this store
-	store := NewLookup()
+	store := NewLookup(gasMeter)
 	api := NewMockAPI()
 	querier := DefaultQuerier(mockContractAddr, types.Coins{types.NewCoin(100, "ATOM")})
 	params, err := json.Marshal(mockEnv(binaryAddr("creator")))
@@ -53,7 +53,7 @@ func TestHumanAddressFailure(t *testing.T) {
 
 	gasMeter := NewMockGasMeter(100000000)
 	// instantiate it with this store
-	store := NewLookup()
+	store := NewLookup(gasMeter)
 	api := NewMockAPI()
 	querier := DefaultQuerier(mockContractAddr, types.Coins{types.NewCoin(100, "ATOM")})
 	params, err := json.Marshal(mockEnv(binaryAddr("creator")))

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -24,7 +24,7 @@ func setupQueueContractWithData(t *testing.T, cache Cache, values ...int) queueD
 
 	gasMeter1 := NewMockGasMeter(100000000)
 	// instantiate it with this store
-	store := NewLookup()
+	store := NewLookup(gasMeter1)
 	api := NewMockAPI()
 	querier := DefaultQuerier(mockContractAddr, types.Coins{types.NewCoin(100, "ATOM")})
 	params, err := json.Marshal(mockEnv(binaryAddr("creator")))

--- a/api/iterator_test.go
+++ b/api/iterator_test.go
@@ -14,9 +14,13 @@ import (
 
 type queueData struct {
 	id      []byte
-	store   KVStore
+	store   *Lookup
 	api     *GoAPI
 	querier types.Querier
+}
+
+func (q queueData) Store(meter GasMeter) KVStore {
+	return q.store.WithGasMeter(meter)
 }
 
 func setupQueueContractWithData(t *testing.T, cache Cache, values ...int) queueData {
@@ -61,10 +65,11 @@ func TestQueueIterator(t *testing.T) {
 	defer cleanup()
 
 	setup := setupQueueContract(t, cache)
-	id, store, querier, api := setup.id, setup.store, setup.querier, setup.api
+	id, querier, api := setup.id, setup.querier, setup.api
 
 	// query the sum
 	gasMeter := NewMockGasMeter(100000000)
+	store := setup.Store(gasMeter)
 	query := []byte(`{"sum":{}}`)
 	data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
@@ -96,11 +101,12 @@ func TestQueueIteratorRaces(t *testing.T) {
 	contract3 := setupQueueContractWithData(t, cache, 11, 6, 2)
 
 	reduceQuery := func(t *testing.T, setup queueData, expected string) {
-		id, store, querier, api := setup.id, setup.store, setup.querier, setup.api
+		id, querier, api := setup.id, setup.querier, setup.api
+		gasMeter := NewMockGasMeter(100000000)
+		store := setup.Store(gasMeter)
 
 		// query reduce (multiple iterators at once)
 		query := []byte(`{"reducer":{}}`)
-		gasMeter := NewMockGasMeter(100000000)
 		data, _, err := Query(cache, id, query, &gasMeter, store, api, &querier, 100000000)
 		require.NoError(t, err)
 		var reduced types.QueryResponse

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -117,7 +116,7 @@ func TestInstantiate(t *testing.T) {
 	res, cost, err := Instantiate(cache, id, params, msg, &gasMeter, store, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
-	assert.Equal(t, uint64(0x1348a)+SetPrice*GasMultiplier, cost)
+	assert.Equal(t, uint64(0x1348a), cost)
 
 	var resp types.InitResult
 	err = json.Unmarshal(res, &resp)
@@ -147,8 +146,8 @@ func TestHandle(t *testing.T) {
 	diff := time.Now().Sub(start)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
-	assert.Equal(t, uint64(0x1348a)+SetPrice*GasMultiplier, cost)
-	fmt.Printf("Time (%d gas): %s\n", 0xbb66, diff)
+	assert.Equal(t, uint64(0x1348a), cost)
+	t.Logf("Time (%d gas): %s\n", 0xbb66, diff)
 
 	// execute with the same store
 	gasMeter2 := NewMockGasMeter(100000000)
@@ -160,7 +159,7 @@ func TestHandle(t *testing.T) {
 	diff = time.Now().Sub(start)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0x1c738), cost)
-	fmt.Printf("Time (%d gas): %s\n", cost, diff)
+	t.Logf("Time (%d gas): %s\n", cost, diff)
 
 	// make sure it read the balance properly and we got 250 atoms
 	var resp types.HandleResult
@@ -201,8 +200,8 @@ func TestHandleCpuLoop(t *testing.T) {
 	diff := time.Now().Sub(start)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
-	assert.Equal(t, uint64(0x1348a)+SetPrice*GasMultiplier, cost)
-	fmt.Printf("Time (%d gas): %s\n", 0xbb66, diff)
+	assert.Equal(t, uint64(0x1348a), cost)
+	t.Logf("Time (%d gas): %s\n", 0xbb66, diff)
 
 	// execute a cpu loop
 	maxGas := uint64(40_000_000)
@@ -215,7 +214,7 @@ func TestHandleCpuLoop(t *testing.T) {
 	diff = time.Now().Sub(start)
 	require.Error(t, err)
 	assert.Equal(t, cost, maxGas)
-	fmt.Printf("CPULoop Time (%d gas): %s\n", cost, diff)
+	t.Logf("CPULoop Time (%d gas): %s\n", cost, diff)
 }
 
 func TestHandleStorageLoop(t *testing.T) {
@@ -253,7 +252,7 @@ func TestHandleStorageLoop(t *testing.T) {
 	t.Logf("Wasm gas: %d\n", cost)
 
 	// the "sdk gas" * GasMultiplier + the wasm cost should equal the maxGas (or be very close)
-	totalCost := cost + gasMeter2.GasConsumed() * GasMultiplier
+	totalCost := cost + gasMeter2.GasConsumed()*GasMultiplier
 	require.Equal(t, int64(maxGas), int64(totalCost))
 }
 
@@ -320,7 +319,7 @@ func TestMultipleInstances(t *testing.T) {
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
 	// we now count wasm gas charges and db writes
-	assert.Equal(t, uint64(0x1348a)+SetPrice*GasMultiplier, cost)
+	assert.Equal(t, uint64(0x1348a), cost)
 
 	// instance2 controlled by mary
 	gasMeter2 := NewMockGasMeter(100000000)
@@ -331,7 +330,7 @@ func TestMultipleInstances(t *testing.T) {
 	res, cost, err = Instantiate(cache, id, params, msg, &gasMeter2, store2, api, &querier, 100000000)
 	require.NoError(t, err)
 	requireOkResponse(t, res, 0)
-	assert.Equal(t, uint64(0x1348a)+SetPrice*GasMultiplier, cost)
+	assert.Equal(t, uint64(0x1348a), cost)
 
 	// fail to execute store1 with mary
 	resp := exec(t, cache, id, "mary", store1, api, querier, 0x119df)

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -249,9 +249,12 @@ func TestHandleStorageLoop(t *testing.T) {
 	diff := time.Now().Sub(start)
 	require.Error(t, err)
 	t.Logf("StorageLoop Time (%d gas): %s\n", cost, diff)
-
 	t.Logf("Gas used: %d\n", gasMeter2.GasConsumed())
 	t.Logf("Wasm gas: %d\n", cost)
+
+	// the "sdk gas" * GasMultiplier + the wasm cost should equal the maxGas (or be very close)
+	totalCost := cost + gasMeter2.GasConsumed() * GasMultiplier
+	require.Equal(t, int64(maxGas), int64(totalCost))
 }
 
 func TestMigrate(t *testing.T) {

--- a/api/mock_test.go
+++ b/api/mock_test.go
@@ -120,6 +120,13 @@ func (l *Lookup) SetGasMeter(meter GasMeter) {
 	l.meter = meter
 }
 
+func (l *Lookup) WithGasMeter(meter GasMeter) *Lookup {
+	return &Lookup{
+		db:    l.db,
+		meter: meter,
+	}
+}
+
 // Get wraps the underlying DB's Get method panicing on error.
 func (l Lookup) Get(key []byte) []byte {
 	l.meter.ConsumeGas(GetPrice, "get")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ fn do_init(
     let mut instance = cache.get_instance(&code_id, deps, gas_limit)?;
     // We only check this result after reporting gas usage and returning the instance into the cache.
     let res = call_init_raw(&mut instance, params, msg);
-    *gas_used = gas_limit - instance.get_gas_left();
+    *gas_used = instance.create_gas_report().used_internally;
     instance.recycle();
     Ok(res?)
 }
@@ -249,7 +249,7 @@ fn do_handle(
     let mut instance = cache.get_instance(&code_id, deps, gas_limit)?;
     // We only check this result after reporting gas usage and returning the instance into the cache.
     let res = call_handle_raw(&mut instance, params, msg);
-    *gas_used = gas_limit - instance.get_gas_left();
+    *gas_used = instance.create_gas_report().used_internally;
     instance.recycle();
     Ok(res?)
 }
@@ -310,7 +310,7 @@ fn do_migrate(
     let mut instance = cache.get_instance(&code_id, deps, gas_limit)?;
     // We only check this result after reporting gas usage and returning the instance into the cache.
     let res = call_migrate_raw(&mut instance, params, msg);
-    *gas_used = gas_limit - instance.get_gas_left();
+    *gas_used = instance.create_gas_report().used_internally;
     instance.recycle();
     Ok(res?)
 }
@@ -358,7 +358,7 @@ fn do_query(
     let mut instance = cache.get_instance(&code_id, deps, gas_limit)?;
     // We only check this result after reporting gas usage and returning the instance into the cache.
     let res = call_query_raw(&mut instance, msg);
-    *gas_used = gas_limit - instance.get_gas_left();
+    *gas_used = instance.create_gas_report().used_internally;
     instance.recycle();
     Ok(res?)
 }


### PR DESCRIPTION
Closes #119 

So far, this just demonstrates this is a real problem. The `cost` returned from `handle` or `init` includes all the external costs from the sdk. We should just use those to stop early, not include them in our cost.

`TestHandleStorageLoop` shows this quite clearly, how the numbers add up too high. But you can also see it in all the other diffs, where the storage cost is now added in, eg:

`assert.Equal(t, uint64(0x1348a), cost)`
becomes
`assert.Equal(t, uint64(0x1348a)+SetPrice*GasMultiplier, cost)`

As soon as we start charging the gasMeter in our mock storage (Lookup).