### PR TITLE
Consume gas even on error inside a query

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -164,7 +164,7 @@ func (w *Wasmer) Query(
 ) ([]byte, uint64, error) {
 	data, gasUsed, err := api.Query(w.cache, code, queryMsg, &gasMeter, store, &goapi, &querier, gasLimit)
 	if err != nil {
-		return nil, 0, err
+		return nil, gasUsed, err
 	}
 
 	var resp types.QueryResponse


### PR DESCRIPTION
In Enigma we are charging gas even for errors in order to prevent abuse/DoS. This PR makes it so that gas is consumed if the query errored but still returned `gas_used`.

Cc @reuvenpo  