### PR TITLE
Remove cache_size from go interface

### DIFF
--- a/api/bindings.h
+++ b/api/bindings.h
@@ -142,7 +142,7 @@ Buffer handle(cache_t *cache,
               uint64_t *gas_used,
               Buffer *err);
 
-cache_t *init_cache(Buffer data_dir, Buffer supported_features, uintptr_t _cache_size, Buffer *err);
+cache_t *init_cache(Buffer data_dir, Buffer supported_features, Buffer *err);
 
 Buffer instantiate(cache_t *cache,
                    Buffer contract_id,

--- a/api/lib.go
+++ b/api/lib.go
@@ -26,14 +26,14 @@ type Cache struct {
 
 type Querier = types.Querier
 
-func InitCache(dataDir string, supportedFeatures string, cacheSize uint64) (Cache, error) {
+func InitCache(dataDir string, supportedFeatures string) (Cache, error) {
 	dir := sendSlice([]byte(dataDir))
 	defer freeAfterSend(dir)
 	features := sendSlice([]byte(supportedFeatures))
 	defer freeAfterSend(features)
 	errmsg := C.Buffer{}
 
-	ptr, err := C.init_cache(dir, features, usize(cacheSize), &errmsg)
+	ptr, err := C.init_cache(dir, features, &errmsg)
 	if err != nil {
 		return Cache{}, errorWithMessage(err, errmsg)
 	}

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -17,14 +17,14 @@ const DEFAULT_FEATURES = "staking"
 
 func TestInitAndReleaseCache(t *testing.T) {
 	dataDir := "/foo"
-	_, err := InitCache(dataDir, DEFAULT_FEATURES, 3)
+	_, err := InitCache(dataDir, DEFAULT_FEATURES)
 	require.Error(t, err)
 
 	tmpdir, err := ioutil.TempDir("", "go-cosmwasm")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	cache, err := InitCache(tmpdir, DEFAULT_FEATURES, 3)
+	cache, err := InitCache(tmpdir, DEFAULT_FEATURES)
 	require.NoError(t, err)
 	ReleaseCache(cache)
 }
@@ -32,7 +32,7 @@ func TestInitAndReleaseCache(t *testing.T) {
 func withCache(t *testing.T) (Cache, func()) {
 	tmpdir, err := ioutil.TempDir("", "go-cosmwasm")
 	require.NoError(t, err)
-	cache, err := InitCache(tmpdir, DEFAULT_FEATURES, 3)
+	cache, err := InitCache(tmpdir, DEFAULT_FEATURES)
 	require.NoError(t, err)
 
 	cleanup := func() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,7 @@ func main() {
 	fmt.Println("Loaded!")
 
 	os.MkdirAll("tmp", 0755)
-	wasmer, err := wasm.NewWasmer("tmp", "staking", 0)
+	wasmer, err := wasm.NewWasmer("tmp", "staking")
 	if err != nil {
 		panic(err)
 	}

--- a/lib.go
+++ b/lib.go
@@ -38,8 +38,8 @@ type Wasmer struct {
 // cacheSize sets the size of an optional in-memory LRU cache for prepared VMs.
 // They allow popular contracts to be executed very rapidly (no loading overhead),
 // but require ~32-64MB each in memory usage.
-func NewWasmer(dataDir string, supportedFeatures string, cacheSize uint64) (*Wasmer, error) {
-	cache, err := api.InitCache(dataDir, supportedFeatures, cacheSize)
+func NewWasmer(dataDir string, supportedFeatures string) (*Wasmer, error) {
+	cache, err := api.InitCache(dataDir, supportedFeatures)
 	if err != nil {
 		return nil, err
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,6 @@ fn to_extern(storage: DB, api: GoApi, querier: GoQuerier) -> Extern<DB, GoApi, G
 pub extern "C" fn init_cache(
     data_dir: Buffer,
     supported_features: Buffer,
-    // TODO: remove unused cache size
-    _cache_size: usize,
     err: Option<&mut Buffer>,
 ) -> *mut cache_t {
     let r = catch_unwind(|| do_init_cache(data_dir, supported_features))


### PR DESCRIPTION
It was supported down to the ffi layer, then ignored. Remove it completely.