### PR TITLE
QueryResponse has custom marshaller for double empty case

### DIFF
--- a/types/queries.go
+++ b/types/queries.go
@@ -6,9 +6,20 @@ import (
 
 //-------- Queries --------
 
-type QueryResponse struct {
+type RawQueryResponse struct {
 	Ok  []byte `json:"ok,omitempty"`
 	Err string `json:"error,omitempty"`
+}
+
+
+type QueryResponse RawQueryResponse
+
+func (q QueryResponse) MarshalJSON() ([]byte, error) {
+	if len(q.Ok) == 0 && len(q.Err) == 0 {
+		return []byte(`{"ok":""}`), nil
+	}
+	raw := RawQueryResponse(q)
+	return json.Marshal(raw)
 }
 
 //-------- Querier -----------

--- a/types/queries_test.go
+++ b/types/queries_test.go
@@ -61,3 +61,51 @@ func TestValidatorWithData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, reval, val)
 }
+
+func TestQueryResponseWithEmptyData(t *testing.T) {
+	cases := map[string]struct{
+		req QueryResponse
+		resp string
+		unmarshal bool
+	}{
+		"ok with data": {
+			req: QueryResponse{Ok:  []byte("foo")},
+			// base64-encoded "foo"
+			resp: `{"ok":"Zm9v"}`,
+			unmarshal: true,
+		},
+		"error": {
+			req: QueryResponse{Err: "try again later"},
+			resp: `{"error":"try again later"}`,
+			unmarshal: true,
+		},
+		"ok with empty slice": {
+			req: QueryResponse{Ok: []byte{}},
+			resp: `{"ok":""}`,
+			unmarshal: true,
+		},
+		"nil data": {
+			req: QueryResponse{},
+			resp: `{"ok":""}`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data, err := json.Marshal(tc.req)
+			require.NoError(t, err)
+			require.Equal(t, tc.resp, string(data))
+
+			// if unmarshall, make sure this comes back to the proper state
+			if tc.unmarshal {
+				var parsed QueryResponse
+				err = json.Unmarshal(data, &parsed)
+				require.NoError(t, err)
+				require.Equal(t, tc.req, parsed)
+			}
+		})
+	}
+
+
+
+}


### PR DESCRIPTION
Makes sure when we return an empty slice as Ok, this is encoded as `{"ok":""}`, which will decode to a value rust enum. Previously it encoded as `{}`, which caused a rust parse error. This only showed up when testing wasm raw queries: https://github.com/CosmWasm/wasmd/pull/281

