### PR TITLE
Polish QueryResponse

### DIFF
--- a/types/queries.go
+++ b/types/queries.go
@@ -7,8 +7,10 @@ import (
 //-------- Queries --------
 
 // QueryResponse is the Go counterpart of `ContractResult<Binary>`.
-// The JSON annotations here are used for deserializing only. There is a custom serializer below.
-type QueryResponse struct {
+// The JSON annotations are used for deserializing directly. There is a custom serializer below.
+type QueryResponse queryResponseImpl
+
+type queryResponseImpl struct {
 	Ok  []byte `json:"ok,omitempty"`
 	Err string `json:"error,omitempty"`
 }
@@ -21,14 +23,7 @@ func (q QueryResponse) MarshalJSON() ([]byte, error) {
 	if len(q.Ok) == 0 && len(q.Err) == 0 {
 		return []byte(`{"ok":""}`), nil
 	}
-
-	return json.Marshal(&struct {
-		Ok  []byte `json:"ok,omitempty"`
-		Err string `json:"error,omitempty"`
-	}{
-		Ok:  q.Ok,
-		Err: q.Err,
-	})
+	return json.Marshal(queryResponseImpl(q))
 }
 
 //-------- Querier -----------

--- a/types/queries.go
+++ b/types/queries.go
@@ -6,20 +6,29 @@ import (
 
 //-------- Queries --------
 
-type RawQueryResponse struct {
+// QueryResponse is the Go counterpart of `ContractResult<Binary>`.
+// The JSON annotations here are used for deserializing only. There is a custom serializer below.
+type QueryResponse struct {
 	Ok  []byte `json:"ok,omitempty"`
 	Err string `json:"error,omitempty"`
 }
 
-
-type QueryResponse RawQueryResponse
-
+// A custom serializer that allows us to map QueryResponse instances to the Rust
+// enum `ContractResult<Binary>`
 func (q QueryResponse) MarshalJSON() ([]byte, error) {
+	// In case both Ok and Err are empty, this is interpreted and seralized
+	// as an Ok case with no data because errors must not be empty.
 	if len(q.Ok) == 0 && len(q.Err) == 0 {
 		return []byte(`{"ok":""}`), nil
 	}
-	raw := RawQueryResponse(q)
-	return json.Marshal(raw)
+
+	return json.Marshal(&struct {
+		Ok  []byte `json:"ok,omitempty"`
+		Err string `json:"error,omitempty"`
+	}{
+		Ok:  q.Ok,
+		Err: q.Err,
+	})
 }
 
 //-------- Querier -----------

--- a/types/queries_test.go
+++ b/types/queries_test.go
@@ -63,29 +63,29 @@ func TestValidatorWithData(t *testing.T) {
 }
 
 func TestQueryResponseWithEmptyData(t *testing.T) {
-	cases := map[string]struct{
-		req QueryResponse
-		resp string
+	cases := map[string]struct {
+		req       QueryResponse
+		resp      string
 		unmarshal bool
 	}{
 		"ok with data": {
-			req: QueryResponse{Ok:  []byte("foo")},
+			req: QueryResponse{Ok: []byte("foo")},
 			// base64-encoded "foo"
-			resp: `{"ok":"Zm9v"}`,
+			resp:      `{"ok":"Zm9v"}`,
 			unmarshal: true,
 		},
 		"error": {
-			req: QueryResponse{Err: "try again later"},
-			resp: `{"error":"try again later"}`,
+			req:       QueryResponse{Err: "try again later"},
+			resp:      `{"error":"try again later"}`,
 			unmarshal: true,
 		},
 		"ok with empty slice": {
-			req: QueryResponse{Ok: []byte{}},
-			resp: `{"ok":""}`,
+			req:       QueryResponse{Ok: []byte{}},
+			resp:      `{"ok":""}`,
 			unmarshal: true,
 		},
 		"nil data": {
-			req: QueryResponse{},
+			req:  QueryResponse{},
 			resp: `{"ok":""}`,
 		},
 	}
@@ -105,7 +105,5 @@ func TestQueryResponseWithEmptyData(t *testing.T) {
 			}
 		})
 	}
-
-
 
 }

--- a/types/queries_test.go
+++ b/types/queries_test.go
@@ -87,6 +87,12 @@ func TestQueryResponseWithEmptyData(t *testing.T) {
 		"nil data": {
 			req:  QueryResponse{},
 			resp: `{"ok":""}`,
+			// Once converted to the Rust enum `ContractResult<Binary>` or
+			// its JSON serialization, we cannot differentiate between
+			// nil and an empty slice anymore. As a consequence,
+			// only this or the above deserialization test can be executed.
+			// We prefer empty slice over nil for no reason.
+			unmarshal: false,
 		},
 	}
 


### PR DESCRIPTION
Some additions to the code to help understand what the f** is going on here.

Removed the type `RawQueryResponse` because we already have way too many types in that flow. It is serializer-internal now.

Overall no functional change as the logic seems to be as good as we can get for now.