### PR TITLE
Expose print debug to go

### DIFF
--- a/api/bindings.h
+++ b/api/bindings.h
@@ -143,7 +143,7 @@ Buffer handle(cache_t *cache,
               uint64_t *gas_used,
               Buffer *err);
 
-cache_t *init_cache(Buffer data_dir, Buffer supported_features, Buffer *err);
+cache_t *init_cache(Buffer data_dir, Buffer supported_features, bool print_debug, Buffer *err);
 
 Buffer instantiate(cache_t *cache,
                    Buffer contract_id,

--- a/api/lib.go
+++ b/api/lib.go
@@ -26,14 +26,14 @@ type Cache struct {
 
 type Querier = types.Querier
 
-func InitCache(dataDir string, supportedFeatures string) (Cache, error) {
+func InitCache(dataDir string, supportedFeatures string, printDebug bool) (Cache, error) {
 	dir := sendSlice([]byte(dataDir))
 	defer freeAfterSend(dir)
 	features := sendSlice([]byte(supportedFeatures))
 	defer freeAfterSend(features)
 	errmsg := C.Buffer{}
 
-	ptr, err := C.init_cache(dir, features, &errmsg)
+	ptr, err := C.init_cache(dir, features, (C._Bool)(printDebug), &errmsg)
 	if err != nil {
 		return Cache{}, errorWithMessage(err, errmsg)
 	}

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -17,14 +17,14 @@ const DEFAULT_FEATURES = "staking"
 
 func TestInitAndReleaseCache(t *testing.T) {
 	dataDir := "/foo"
-	_, err := InitCache(dataDir, DEFAULT_FEATURES)
+	_, err := InitCache(dataDir, DEFAULT_FEATURES, true)
 	require.Error(t, err)
 
 	tmpdir, err := ioutil.TempDir("", "go-cosmwasm")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	cache, err := InitCache(tmpdir, DEFAULT_FEATURES)
+	cache, err := InitCache(tmpdir, DEFAULT_FEATURES, true)
 	require.NoError(t, err)
 	ReleaseCache(cache)
 }
@@ -32,7 +32,7 @@ func TestInitAndReleaseCache(t *testing.T) {
 func withCache(t *testing.T) (Cache, func()) {
 	tmpdir, err := ioutil.TempDir("", "go-cosmwasm")
 	require.NoError(t, err)
-	cache, err := InitCache(tmpdir, DEFAULT_FEATURES)
+	cache, err := InitCache(tmpdir, DEFAULT_FEATURES, true)
 	require.NoError(t, err)
 
 	cleanup := func() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,7 @@ func main() {
 	fmt.Println("Loaded!")
 
 	os.MkdirAll("tmp", 0755)
-	wasmer, err := wasm.NewWasmer("tmp", "staking")
+	wasmer, err := wasm.NewWasmer("tmp", "staking", true)
 	if err != nil {
 		panic(err)
 	}

--- a/lib.go
+++ b/lib.go
@@ -38,8 +38,8 @@ type Wasmer struct {
 // cacheSize sets the size of an optional in-memory LRU cache for prepared VMs.
 // They allow popular contracts to be executed very rapidly (no loading overhead),
 // but require ~32-64MB each in memory usage.
-func NewWasmer(dataDir string, supportedFeatures string) (*Wasmer, error) {
-	cache, err := api.InitCache(dataDir, supportedFeatures)
+func NewWasmer(dataDir string, supportedFeatures string, printDebug bool) (*Wasmer, error) {
+	cache, err := api.InitCache(dataDir, supportedFeatures, printDebug)
 	if err != nil {
 		return nil, err
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,10 @@ fn to_extern(storage: DB, api: GoApi, querier: GoQuerier) -> Extern<DB, GoApi, G
 pub extern "C" fn init_cache(
     data_dir: Buffer,
     supported_features: Buffer,
+    print_debug: bool,
     err: Option<&mut Buffer>,
 ) -> *mut cache_t {
-    let r = catch_unwind(|| do_init_cache(data_dir, supported_features))
+    let r = catch_unwind(|| do_init_cache(data_dir, supported_features, print_debug))
         .unwrap_or_else(|_| Err(Error::panic()));
     match r {
         Ok(t) => {
@@ -73,11 +74,10 @@ static ENV_ARG: &str = "env";
 static INFO_ARG: &str = "message_info";
 static GAS_USED_ARG: &str = "gas_used";
 
-const PRINT_DEBUG: bool = false;
-
 fn do_init_cache(
     data_dir: Buffer,
     supported_features: Buffer,
+    print_debug: bool,
 ) -> Result<*mut CosmCache<DB, GoApi, GoQuerier>, Error> {
     let dir = unsafe { data_dir.read() }.ok_or_else(|| Error::empty_arg(DATA_DIR_ARG))?;
     let dir_str = from_utf8(dir)?;
@@ -86,7 +86,7 @@ fn do_init_cache(
         unsafe { supported_features.read() }.ok_or_else(|| Error::empty_arg(FEATURES_ARG))?;
     let features_str = from_utf8(features_bin)?;
     let features = features_from_csv(features_str);
-    let cache = unsafe { CosmCache::new(dir_str, features, PRINT_DEBUG) }?;
+    let cache = unsafe { CosmCache::new(dir_str, features, print_debug) }?;
     let out = Box::new(cache);
     Ok(Box::into_raw(out))
 }


### PR DESCRIPTION
Allows us to use go-cosmwasm in go integration tests and switch on the in-contract debug statements from the caller code.
(Previously it required us to change a rust const and recompile the dll).

Breaking change for 0.11 (adds one more arg to a function) - slatted for 0.12